### PR TITLE
Polish mobile docs terminals

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@ skills/worktrunk/reference/troubleshooting.md linguist-generated=false
 docs/public/*.md linguist-generated=true
 docs/public/llms.txt linguist-generated=true
 docs/public/.well-known/agent-skills/index.json linguist-generated=true
+docs/src/generated/terminal-styles.json linguist-generated=true
 # Shell templates are embedded into the binary at compile time (askama); a
 # CRLF checkout would leak \r into the shell code Windows-built binaries emit.
 templates/* text eol=lf

--- a/.github/actions/docs-build/action.yaml
+++ b/.github/actions/docs-build/action.yaml
@@ -16,6 +16,11 @@ runs:
       run: npm ci
       working-directory: docs
 
+    - name: Install WebKit for mobile layout tests
+      shell: bash
+      run: npx playwright install --with-deps webkit
+      working-directory: docs
+
     - name: Fetch docs assets
       shell: bash
       env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ globs = [
     "docs/**/*.md",
     "docs/public/llms.txt",
     "docs/public/.well-known/agent-skills/index.json",
+    "docs/src/generated/terminal-styles.json",
     "dev/*.toml",
     "src/cli/mod.rs",
     "src/llm.rs",

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -12,6 +12,7 @@ To run it yourself:
 
 ```bash
 npm --prefix docs install
+npm --prefix docs exec playwright install webkit
 npm --prefix docs run dev -- --host 127.0.0.1 --port 4321
 ```
 
@@ -51,9 +52,10 @@ View changes: http://127.0.0.1:<port>
 | `src/pages/index.astro` | Homepage route; renders the canonical `worktrunk.md` body |
 | `src/styles/custom.css` | Worktrunk's visual system and narrow Starlight adjustments |
 | `src/plugins/stable-heading-ids.mjs` | Stable public anchor IDs for Markdown headings |
-| `src/plugins/worktrunk-terminal.mjs` | Prompts, copy behavior, and state colors for `console` fences |
+| `src/plugins/worktrunk-terminal.mjs` | Prompts, copy behavior, and ANSI-derived styling for `console` fences |
+| `src/generated/terminal-styles.json` | Generated site-only span styles from ANSI command snapshots |
 | `src/components/Head.astro` | Social metadata, structured data, and analytics |
-| `tests/` | Renderer unit tests and built-site route/link checks |
+| `tests/` | Renderer unit tests plus built-site and WebKit mobile checks |
 | `public/` | Files served unchanged at the site root |
 | `demos/` | VHS sources and scripts for the external demo assets |
 
@@ -184,7 +186,10 @@ $ wt list
 The mapping lives in `tests/integration_tests/readme_sync.rs`. The generated
 site page uses the real command plus ANSI-stripped output in one `console`
 fence. This keeps the Markdown readable on GitHub and lets the site renderer
-add prompts and command-only copy behavior without changing the source.
+add prompts and command-only copy behavior without changing the source. The
+same sync pass writes `src/generated/terminal-styles.json` from the snapshot's
+ANSI spans, so the website preserves the CLI's exact semantic colors and text
+attributes while every portable Markdown surface remains plain text.
 
 To update an example:
 
@@ -217,9 +222,9 @@ Starlight and Expressive Code create the terminal frame and copy button. The
 small Worktrunk plugin removes `$ ` from presentation data, renders it as a
 prompt, and makes mixed blocks copy only their commands. Comment lines and
 blank recipe separators remain copyable; captured output does not. The plugin
-also restores green/red/amber state markers from the portable text rather than
-putting ANSI escapes in Markdown. Committed Markdown must remain useful without
-the plugin.
+restores exact ANSI roles from the generated style manifest for snapshot-backed
+examples; hand-written output uses a conservative marker fallback. Committed
+Markdown must remain useful without the plugin.
 
 ### Web-only post-processing
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "parity": "node scripts/parity.mjs",
     "preview": "astro preview",
     "test": "node --test tests/plugins.test.mjs",
-    "test:site": "node --test tests/built-site.test.mjs"
+    "test:site": "node --test tests/built-site.test.mjs tests/browser-site.test.mjs"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.4",

--- a/docs/src/generated/terminal-styles.json
+++ b/docs/src/generated/terminal-styles.json
@@ -1,0 +1,4506 @@
+[
+  {
+    "lines": [
+      [
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Branch"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Status"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "HEAD±"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main↕"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main…±"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Remote⇅"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Commit"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Age"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Message"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "@ feature-auth  "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "+"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↑"
+        },
+        {
+          "classes": [],
+          "text": "      "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+27"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-8"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑1"
+        },
+        {
+          "classes": [],
+          "text": "       "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+31"
+        },
+        {
+          "classes": [],
+          "text": "                "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "4bc72dc"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "2h"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Add authenticati…"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "^ main              "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "^⇡"
+        },
+        {
+          "classes": [],
+          "text": "                                    "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "⇡1"
+        },
+        {
+          "classes": [],
+          "text": "      "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "0e631ad"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "1d"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Initial commit"
+        }
+      ],
+      [],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "○"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden"
+        }
+      ]
+    ],
+    "plain": "  Branch        Status        HEAD±    main↕     main…±  Remote⇅  Commit   Age   Message\n@ feature-auth  +   ↑      +27   -8   ↑1       +31                4bc72dc  2h    Add authenticati…\n^ main              ^⇡                                    ⇡1      0e631ad  1d    Initial commit\n\n○ Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Branch"
+        },
+        {
+          "classes": [],
+          "text": "       "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Status"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "HEAD±"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main↕"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main…±"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Remote⇅"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Commit"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Age"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Message"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "@ feature-api  "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "+"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↕⇡"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+54"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-5"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑4"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "↓1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+234"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-24"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "⇡3"
+        },
+        {
+          "classes": [],
+          "text": "      "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "6814f02"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "30m"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Add API tests"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "^ main             "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "^⇅"
+        },
+        {
+          "classes": [],
+          "text": "                                    "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "⇡1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "⇣1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "41ee083"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "4d"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Merge fix-auth: h…"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ fix-auth         "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↕|"
+        },
+        {
+          "classes": [],
+          "text": "                "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑2"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "↓1"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+25"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-11"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "|"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "b772e68"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "5h"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Add secure token…"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "fix-typos"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "_|"
+        },
+        {
+          "classes": [],
+          "text": "                                      "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "|"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "41ee083"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "4d"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Merge fix-auth: h…"
+        }
+      ],
+      [],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "○"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Showing 4 worktrees, 1 with changes, 2 ahead, 1 column hidden"
+        }
+      ]
+    ],
+    "plain": "  Branch       Status        HEAD±    main↕     main…±  Remote⇅  Commit   Age   Message\n@ feature-api  +   ↕⇡     +54   -5   ↑4  ↓1  +234  -24   ⇡3      6814f02  30m   Add API tests\n^ main             ^⇅                                    ⇡1  ⇣1  41ee083  4d    Merge fix-auth: h…\n+ fix-auth         ↕|                ↑2  ↓1   +25  -11     |     b772e68  5h    Add secure token…\n+ fix-typos        _|                                      |     41ee083  4d    Merge fix-auth: h…\n\n○ Showing 4 worktrees, 1 with changes, 2 ahead, 1 column hidden"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Branch"
+        },
+        {
+          "classes": [],
+          "text": "       "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Status"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "HEAD±"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main↕"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main…±"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Remote⇅"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Commit"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Age"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Message"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "@ main             "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "^⇡"
+        },
+        {
+          "classes": [],
+          "text": "                                    "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "⇡1"
+        },
+        {
+          "classes": [],
+          "text": "      "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "33323bc"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "1d"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Initial commit"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ feature-api      "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↑"
+        },
+        {
+          "classes": [],
+          "text": " 🤖              "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑1"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+1"
+        },
+        {
+          "classes": [],
+          "text": "                "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "70343f0"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "1d"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Add REST API endp…"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ review-ui      "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "?"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↑"
+        },
+        {
+          "classes": [],
+          "text": " 💬    "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+1"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑1"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+1"
+        },
+        {
+          "classes": [],
+          "text": "                "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "a585d6e"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "1d"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Add dashboard com…"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ wip-docs       "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "?"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "–"
+        },
+        {
+          "classes": [],
+          "text": "       "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+1"
+        },
+        {
+          "classes": [],
+          "text": "                                    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "33323bc"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "1d"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Initial commit"
+        }
+      ],
+      [],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "○"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Showing 4 worktrees, 2 with changes, 2 ahead, 1 column hidden"
+        }
+      ]
+    ],
+    "plain": "  Branch       Status        HEAD±    main↕     main…±  Remote⇅  Commit   Age   Message\n@ main             ^⇡                                    ⇡1      33323bc  1d    Initial commit\n+ feature-api      ↑ 🤖              ↑1        +1                70343f0  1d    Add REST API endp…\n+ review-ui      ? ↑ 💬    +1        ↑1        +1                a585d6e  1d    Add dashboard com…\n+ wip-docs       ? –       +1                                    33323bc  1d    Initial commit\n\n○ Showing 4 worktrees, 2 with changes, 2 ahead, 1 column hidden"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Branch"
+        },
+        {
+          "classes": [],
+          "text": "       "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Status"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "HEAD±"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main↕"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main…±"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Remote⇅"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Path"
+        },
+        {
+          "classes": [],
+          "text": "                 "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Commit"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Age"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Message"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "@ main             "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "^⇡"
+        },
+        {
+          "classes": [],
+          "text": "                                    "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "⇡1"
+        },
+        {
+          "classes": [],
+          "text": "      .                    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "33323bc"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "1d"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Initial commit"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ feature-api      "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↑"
+        },
+        {
+          "classes": [],
+          "text": " 🤖              "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑1"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+1"
+        },
+        {
+          "classes": [],
+          "text": "                ../repo.feature-api  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "70343f0"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "1d"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Add REST API endpoints"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ review-ui      "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "?"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↑"
+        },
+        {
+          "classes": [],
+          "text": " 💬    "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+1"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑1"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+1"
+        },
+        {
+          "classes": [],
+          "text": "                ../repo.review-ui    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "a585d6e"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "1d"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Add dashboard component"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ wip-docs       "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "?"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "–"
+        },
+        {
+          "classes": [],
+          "text": "       "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+1"
+        },
+        {
+          "classes": [],
+          "text": "                                    ../repo.wip-docs     "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "33323bc"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "1d"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Initial commit"
+        }
+      ],
+      [],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "○"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Showing 4 worktrees, 2 with changes, 2 ahead"
+        }
+      ]
+    ],
+    "plain": "  Branch       Status        HEAD±    main↕     main…±  Remote⇅  Path                 Commit   Age   Message\n@ main             ^⇡                                    ⇡1      .                    33323bc  1d    Initial commit\n+ feature-api      ↑ 🤖              ↑1        +1                ../repo.feature-api  70343f0  1d    Add REST API endpoints\n+ review-ui      ? ↑ 💬    +1        ↑1        +1                ../repo.review-ui    a585d6e  1d    Add dashboard component\n+ wip-docs       ? –       +1                                    ../repo.wip-docs     33323bc  1d    Initial commit\n\n○ Showing 4 worktrees, 2 with changes, 2 ahead"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Branch"
+        },
+        {
+          "classes": [],
+          "text": "       "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Status"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "HEAD±"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main↕"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main…±"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Remote⇅"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "URL"
+        },
+        {
+          "classes": [],
+          "text": "                     "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Commit"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "@ main           "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "?"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "^⇅"
+        },
+        {
+          "classes": [],
+          "text": "      "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+5"
+        },
+        {
+          "classes": [],
+          "text": "                            "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "⇡1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "⇣1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "http://localhost:12107"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "41ee083"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ feature-api  "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "+"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↕⇡"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+54"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-5"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑4"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "↓1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+234"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-24"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "⇡3"
+        },
+        {
+          "classes": [],
+          "text": "      "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "http://localhost:10703"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "6814f02"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ fix-auth         "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↕|"
+        },
+        {
+          "classes": [],
+          "text": "                "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑2"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "↓1"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+25"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-11"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "|"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "http://localhost:16460"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "b772e68"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "fix-typos"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "_|"
+        },
+        {
+          "classes": [],
+          "text": "                                      "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "|"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "http://localhost:14301"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "41ee083"
+        }
+      ],
+      [],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "○"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Showing 4 worktrees, 2 with changes, 2 ahead, 3 columns hidden"
+        }
+      ]
+    ],
+    "plain": "  Branch       Status        HEAD±    main↕     main…±  Remote⇅  URL                     Commit\n@ main           ? ^⇅      +5                            ⇡1  ⇣1  http://localhost:12107  41ee083\n+ feature-api  +   ↕⇡     +54   -5   ↑4  ↓1  +234  -24   ⇡3      http://localhost:10703  6814f02\n+ fix-auth         ↕|                ↑2  ↓1   +25  -11     |     http://localhost:16460  b772e68\n+ fix-typos        _|                                      |     http://localhost:14301  41ee083\n\n○ Showing 4 worktrees, 2 with changes, 2 ahead, 3 columns hidden"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Branch"
+        },
+        {
+          "classes": [],
+          "text": "       "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Status"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "HEAD±"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main↕"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main…±"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Summary"
+        },
+        {
+          "classes": [],
+          "text": "                                                 "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Remote⇅"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "CI"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Commit"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "@ feature-api  "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "+"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↕⇡"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+54"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-5"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑4"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "↓1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+234"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-24"
+        },
+        {
+          "classes": [],
+          "text": "  Refactor API to REST architecture with middleware        "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "⇡3"
+        },
+        {
+          "classes": [],
+          "text": "      "
+        },
+        {
+          "classes": [
+            "wt-terminal-blue",
+            "wt-terminal-dim"
+          ],
+          "text": "#412"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "6814f02"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "^ main             "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "^⇅"
+        },
+        {
+          "classes": [],
+          "text": "                                                                                            "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "⇡1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "⇣1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "#"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "41ee083"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ fix-auth         "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↕|"
+        },
+        {
+          "classes": [],
+          "text": "                "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑2"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "↓1"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+25"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-11"
+        },
+        {
+          "classes": [],
+          "text": "  Harden auth with constant-time token validation            "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "|"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "#408"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "b772e68"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "fix-typos"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "_|"
+        },
+        {
+          "classes": [],
+          "text": "                                                                                              "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "|"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "#410"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "41ee083"
+        }
+      ],
+      [],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "○"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Showing 4 worktrees, 1 with changes, 2 ahead, 3 columns hidden"
+        }
+      ]
+    ],
+    "plain": "  Branch       Status        HEAD±    main↕     main…±  Summary                                                 Remote⇅  CI    Commit\n@ feature-api  +   ↕⇡     +54   -5   ↑4  ↓1  +234  -24  Refactor API to REST architecture with middleware        ⇡3      #412  6814f02\n^ main             ^⇅                                                                                            ⇡1  ⇣1  #     41ee083\n+ fix-auth         ↕|                ↑2  ↓1   +25  -11  Harden auth with constant-time token validation            |     #408  b772e68\n+ fix-typos        _|                                                                                              |     #410  41ee083\n\n○ Showing 4 worktrees, 1 with changes, 2 ahead, 3 columns hidden"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Branch"
+        },
+        {
+          "classes": [],
+          "text": "       "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Status"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "HEAD±"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main↕"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main…±"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Summary"
+        },
+        {
+          "classes": [],
+          "text": "                                                 "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Remote⇅"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "CI"
+        },
+        {
+          "classes": [],
+          "text": "    "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Commit"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "@ feature-api  "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "+"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↕⇡"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+54"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-5"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑4"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "↓1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+234"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-24"
+        },
+        {
+          "classes": [],
+          "text": "  Refactor API to REST architecture with middleware        "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "⇡3"
+        },
+        {
+          "classes": [],
+          "text": "      "
+        },
+        {
+          "classes": [
+            "wt-terminal-blue",
+            "wt-terminal-dim"
+          ],
+          "text": "#412"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "6814f02"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "^ main             "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "^⇅"
+        },
+        {
+          "classes": [],
+          "text": "                                                                                            "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "⇡1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "⇣1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "#"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "41ee083"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ fix-auth         "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "↕|"
+        },
+        {
+          "classes": [],
+          "text": "                "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑2"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "↓1"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+25"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red"
+          ],
+          "text": "-11"
+        },
+        {
+          "classes": [],
+          "text": "  Harden auth with constant-time token validation            "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "|"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "#408"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "b772e68"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "+ "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "fix-typos"
+        },
+        {
+          "classes": [],
+          "text": "        "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "_|"
+        },
+        {
+          "classes": [],
+          "text": "                                                                                              "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "|"
+        },
+        {
+          "classes": [],
+          "text": "     "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "#410"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "41ee083"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "/ "
+        },
+        {
+          "classes": [],
+          "text": "exp             "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "/↕"
+        },
+        {
+          "classes": [],
+          "text": "                 "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑2"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "↓1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+137"
+        },
+        {
+          "classes": [],
+          "text": "       Explore GraphQL schema and resolvers                                   "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "9637922"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "/ "
+        },
+        {
+          "classes": [],
+          "text": "wip             "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "/↕"
+        },
+        {
+          "classes": [],
+          "text": "                 "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "↑1"
+        },
+        {
+          "classes": [],
+          "text": "  "
+        },
+        {
+          "classes": [
+            "wt-terminal-red",
+            "wt-terminal-dim"
+          ],
+          "text": "↓1"
+        },
+        {
+          "classes": [],
+          "text": "   "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+33"
+        },
+        {
+          "classes": [],
+          "text": "       Start API documentation                                                "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "b40716d"
+        }
+      ],
+      [],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "○"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "Showing 4 worktrees, 2 branches, 1 with changes, 4 ahead, 3 columns hidden"
+        }
+      ]
+    ],
+    "plain": "  Branch       Status        HEAD±    main↕     main…±  Summary                                                 Remote⇅  CI    Commit\n@ feature-api  +   ↕⇡     +54   -5   ↑4  ↓1  +234  -24  Refactor API to REST architecture with middleware        ⇡3      #412  6814f02\n^ main             ^⇅                                                                                            ⇡1  ⇣1  #     41ee083\n+ fix-auth         ↕|                ↑2  ↓1   +25  -11  Harden auth with constant-time token validation            |     #408  b772e68\n+ fix-typos        _|                                                                                              |     #410  41ee083\n/ exp             /↕                 ↑2  ↓1  +137       Explore GraphQL schema and resolvers                                   9637922\n/ wip             /↕                 ↑1  ↓1   +33       Start API documentation                                                b40716d\n\n○ Showing 4 worktrees, 2 branches, 1 with changes, 4 ahead, 3 columns hidden"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Generating commit message and committing changes... "
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": "(2 files, "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+26"
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": ")"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "feat(validation): add input validation utilities"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "✓"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "Committed changes @ "
+        },
+        {
+          "classes": [
+            "wt-terminal-green",
+            "wt-terminal-dim"
+          ],
+          "text": "a1b2c3d"
+        }
+      ]
+    ],
+    "plain": "◎ Generating commit message and committing changes... (2 files, +26)\n  feat(validation): add input validation utilities\n✓ Committed changes @ a1b2c3d"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Generating commit message and committing changes... "
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": "(2 files, "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+53"
+        },
+        {
+          "classes": [],
+          "text": ", no squashing needed"
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": ")"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "Add authentication module"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "✓"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "Committed changes @ "
+        },
+        {
+          "classes": [
+            "wt-terminal-green",
+            "wt-terminal-dim"
+          ],
+          "text": "a1b2c3d"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Merging 1 commit to "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": " @ "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-dim"
+          ],
+          "text": "a1b2c3d"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": " (no rebase needed)"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " * "
+        },
+        {
+          "classes": [
+            "wt-terminal-yellow"
+          ],
+          "text": "a1b2c3d"
+        },
+        {
+          "classes": [],
+          "text": " Add authentication module"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": "  auth.rs | 51 "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+++++++++++++++++++++++++++++++++++++++++++++++++++"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": "  lib.rs  |  2 "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "++"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": "  2 files changed, 53 insertions(+)"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "✓"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "Merged to "
+        },
+        {
+          "classes": [
+            "wt-terminal-green",
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": "(1 commit, 2 files, "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+53"
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": ")"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Removing "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "feature-auth"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": " worktree & branch in background (same commit as "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": ","
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "_"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": ")"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "○"
+        },
+        {
+          "classes": [],
+          "text": " Switched to worktree for "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [],
+          "text": " @ "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "~/repo"
+        }
+      ]
+    ],
+    "plain": "◎ Generating commit message and committing changes... (2 files, +53, no squashing needed)\n  Add authentication module\n✓ Committed changes @ a1b2c3d\n◎ Merging 1 commit to main @ a1b2c3d (no rebase needed)\n  * a1b2c3d Add authentication module\n   auth.rs | 51 +++++++++++++++++++++++++++++++++++++++++++++++++++\n   lib.rs  |  2 ++\n   2 files changed, 53 insertions(+)\n✓ Merged to main (1 commit, 2 files, +53)\n◎ Removing feature-auth worktree & branch in background (same commit as main, _)\n○ Switched to worktree for main @ ~/repo"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Running pre-merge "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "project:test"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-blue",
+            "wt-terminal-dim"
+          ],
+          "text": "cargo"
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": " nextest run"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.02s"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "     Summary [   0.002s] 2 tests run: 2 passed, 0 skipped"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Merging 1 commit to "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": " @ "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-dim"
+          ],
+          "text": "a1b2c3d"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": " (no commit/squash/rebase needed)"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " * "
+        },
+        {
+          "classes": [
+            "wt-terminal-yellow"
+          ],
+          "text": "a1b2c3d"
+        },
+        {
+          "classes": [],
+          "text": " feat: add hook registration"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": "  hook.rs | 31 "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+++++++++++++++++++++++++++++++"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": "  1 file changed, 31 insertions(+)"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "✓"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "Merged to "
+        },
+        {
+          "classes": [
+            "wt-terminal-green",
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": "(1 commit, 1 file, "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+31"
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": ")"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Removing "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "hooks"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": " worktree & branch in background (same commit as "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": ","
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "_"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": ")"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "○"
+        },
+        {
+          "classes": [],
+          "text": " Switched to worktree for "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [],
+          "text": " @ "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "~/repo"
+        }
+      ]
+    ],
+    "plain": "◎ Running pre-merge project:test\n  cargo nextest run\n    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.02s\n     Summary [   0.002s] 2 tests run: 2 passed, 0 skipped\n◎ Merging 1 commit to main @ a1b2c3d (no commit/squash/rebase needed)\n  * a1b2c3d feat: add hook registration\n   hook.rs | 31 +++++++++++++++++++++++++++++++\n   1 file changed, 31 insertions(+)\n✓ Merged to main (1 commit, 1 file, +31)\n◎ Removing hooks worktree & branch in background (same commit as main, _)\n○ Switched to worktree for main @ ~/repo"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Running pre-merge "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "project:test"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-blue",
+            "wt-terminal-dim"
+          ],
+          "text": "cargo"
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": " test"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "    Finished test [unoptimized + debuginfo] target(s) in 0.12s"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "     Running unittests src/lib.rs (target/debug/deps/worktrunk-abc123)"
+        }
+      ],
+      [],
+      [
+        {
+          "classes": [],
+          "text": "running 18 tests"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "test auth::tests::test_jwt_decode ... ok"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "test auth::tests::test_jwt_encode ... ok"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "test auth::tests::test_token_refresh ... ok"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "test auth::tests::test_token_validation ... ok"
+        }
+      ],
+      [],
+      [
+        {
+          "classes": [],
+          "text": "test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Running pre-merge "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "project:lint"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-blue",
+            "wt-terminal-dim"
+          ],
+          "text": "cargo"
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": " clippy"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "    Checking worktrunk v0.1.0"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "    Finished dev [unoptimized + debuginfo] target(s) in 1.23s"
+        }
+      ]
+    ],
+    "plain": "◎ Running pre-merge project:test\n  cargo test\n    Finished test [unoptimized + debuginfo] target(s) in 0.12s\n     Running unittests src/lib.rs (target/debug/deps/worktrunk-abc123)\n\nrunning 18 tests\ntest auth::tests::test_jwt_decode ... ok\ntest auth::tests::test_jwt_encode ... ok\ntest auth::tests::test_token_refresh ... ok\ntest auth::tests::test_token_validation ... ok\n\ntest result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s\n◎ Running pre-merge project:lint\n  cargo clippy\n    Checking worktrunk v0.1.0\n    Finished dev [unoptimized + debuginfo] target(s) in 1.23s"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Running pre-remove "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "project:cleanup"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-blue",
+            "wt-terminal-dim"
+          ],
+          "text": "flyctl"
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": " scale count 0"
+        }
+      ],
+      [
+        {
+          "classes": [],
+          "text": "Scaling app to 0 machines"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Removing "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "api"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": " worktree & branch in background (same commit as "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": ","
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "_"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": ")"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "○"
+        },
+        {
+          "classes": [],
+          "text": " Switched to worktree for "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [],
+          "text": " @ "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "~/repo"
+        }
+      ]
+    ],
+    "plain": "◎ Running pre-remove project:cleanup\n  flyctl scale count 0\nScaling app to 0 machines\n◎ Removing api worktree & branch in background (same commit as main, _)\n○ Switched to worktree for main @ ~/repo"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Squashing 3 commits into a single commit "
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": "(5 files, "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+16"
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": ")"
+        },
+        {
+          "classes": [],
+          "text": "..."
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Generating squash commit message..."
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "feat(auth): Implement JWT authentication system"
+        }
+      ],
+      [],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " Add comprehensive JWT token handling including validation, refresh"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " logic, and authentication tests."
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "✓"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "Squashed @ a1b2c3d"
+        }
+      ]
+    ],
+    "plain": "◎ Squashing 3 commits into a single commit (5 files, +16)...\n◎ Generating squash commit message...\n  feat(auth): Implement JWT authentication system\n\n  Add comprehensive JWT token handling including validation, refresh\n  logic, and authentication tests.\n✓ Squashed @ a1b2c3d"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Squashing 3 commits into a single commit "
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": "(5 files, "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+16"
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": ")"
+        },
+        {
+          "classes": [],
+          "text": "..."
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Generating squash commit message..."
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "feat(auth): Implement JWT authentication system"
+        }
+      ],
+      [],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " Add comprehensive JWT token handling including validation, refresh"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " logic, and authentication tests."
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "✓"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "Squashed @ a1b2c3d"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Merging 1 commit to "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": " @ "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-dim"
+          ],
+          "text": "a1b2c3d"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": " (no rebase needed)"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": " * "
+        },
+        {
+          "classes": [
+            "wt-terminal-yellow"
+          ],
+          "text": "a1b2c3d"
+        },
+        {
+          "classes": [],
+          "text": " feat(auth): Implement JWT authentication system"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": "  auth.rs             | 2 "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "++"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": "  auth_test.rs        | 2 "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "++"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": "  integration_test.rs | 6 "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "++++++"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": "  jwt.rs              | 3 "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+++"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": "  jwt_test.rs         | 3 "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+++"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-gutter"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [],
+          "text": "  5 files changed, 16 insertions(+)"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "✓"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "Merged to "
+        },
+        {
+          "classes": [
+            "wt-terminal-green",
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": "(1 commit, 5 files, "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "+16"
+        },
+        {
+          "classes": [
+            "wt-terminal-gray"
+          ],
+          "text": ")"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "◎"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": "Removing "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "feature"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": " worktree & branch in background (same commit as "
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan",
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": ","
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "_"
+        },
+        {
+          "classes": [
+            "wt-terminal-cyan"
+          ],
+          "text": ")"
+        }
+      ],
+      [
+        {
+          "classes": [
+            "wt-terminal-dim"
+          ],
+          "text": "○"
+        },
+        {
+          "classes": [],
+          "text": " Switched to worktree for "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [],
+          "text": " @ "
+        },
+        {
+          "classes": [
+            "wt-terminal-bold"
+          ],
+          "text": "~/repo"
+        }
+      ]
+    ],
+    "plain": "◎ Squashing 3 commits into a single commit (5 files, +16)...\n◎ Generating squash commit message...\n  feat(auth): Implement JWT authentication system\n\n  Add comprehensive JWT token handling including validation, refresh\n  logic, and authentication tests.\n✓ Squashed @ a1b2c3d\n◎ Merging 1 commit to main @ a1b2c3d (no rebase needed)\n  * a1b2c3d feat(auth): Implement JWT authentication system\n   auth.rs             | 2 ++\n   auth_test.rs        | 2 ++\n   integration_test.rs | 6 ++++++\n   jwt.rs              | 3 +++\n   jwt_test.rs         | 3 +++\n   5 files changed, 16 insertions(+)\n✓ Merged to main (1 commit, 5 files, +16)\n◎ Removing feature worktree & branch in background (same commit as main, _)\n○ Switched to worktree for main @ ~/repo"
+  },
+  {
+    "lines": [
+      [
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "✓"
+        },
+        {
+          "classes": [],
+          "text": " "
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": "Created branch "
+        },
+        {
+          "classes": [
+            "wt-terminal-green",
+            "wt-terminal-bold"
+          ],
+          "text": "feature-auth"
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": " from "
+        },
+        {
+          "classes": [
+            "wt-terminal-green",
+            "wt-terminal-bold"
+          ],
+          "text": "main"
+        },
+        {
+          "classes": [
+            "wt-terminal-green"
+          ],
+          "text": " and worktree @ "
+        },
+        {
+          "classes": [
+            "wt-terminal-green",
+            "wt-terminal-bold"
+          ],
+          "text": "~/repo.feature-auth"
+        }
+      ]
+    ],
+    "plain": "✓ Created branch feature-auth from main and worktree @ ~/repo.feature-auth"
+  }
+]

--- a/docs/src/plugins/worktrunk-terminal.mjs
+++ b/docs/src/plugins/worktrunk-terminal.mjs
@@ -1,10 +1,14 @@
-const terminalBlocks = new WeakMap();
+import terminalStyles from '../generated/terminal-styles.json' with { type: 'json' };
 
-// Bare `+` is a status only at a line edge or between wide table columns;
-// ordinary prose such as `[unoptimized + debuginfo]` stays neutral.
-const semanticMarker = /([+↑⇡]\d+|[↑⇡]|(?<!\s)\+|\+(?!\s)|(?<=^|\s\s)\+(?=\s\s|\s*$)|[-↓⇣]\d+|✓|✗|(?<=^|\s)[!?](?=\s|$))/gmu;
+const terminalBlocks = new WeakMap();
+const recordedTerminalBlocks = new Map(
+  terminalStyles.map(({ plain, lines }) => [plain, lines]),
+);
+
+const semanticMarker = /((?:(?<=^)|(?<=\s{2}))[-+↑⇡↓⇣]\d+(?=\s{2}|$)|✓|✗|(?<=^|\s)[!?](?=\s|$))/gmu;
 
 function addClass(node, className) {
+  node.properties ??= {};
   const classes = node.properties.className ?? [];
   node.properties.className = Array.isArray(classes)
     ? [...classes, className]
@@ -91,7 +95,73 @@ function renderSemanticOutput(lineAst, text) {
         properties: { className: [`wt-${tone}`] },
         children: [{ type: 'text', value }],
       }
+      : { type: 'text', value });
+}
+
+function renderRecordedOutput(lineAst, segments) {
+  const code = findCodeElement(lineAst);
+  if (!code) return false;
+  code.children = segments.map(({ text: value, classes }) => classes.length > 0
+    ? {
+        type: 'element',
+        tagName: 'span',
+        properties: { className: classes },
+        children: [{ type: 'text', value }],
+      }
     : { type: 'text', value });
+  return true;
+}
+
+function shellCommentIndex(text) {
+  let quote;
+  let escaped = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (character === quote) {
+      quote = undefined;
+      continue;
+    }
+    if (!quote && (character === "'" || character === '"')) {
+      quote = character;
+      continue;
+    }
+    if (!quote && character === '#' && (index === 0 || /\s/u.test(text[index - 1]))) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function renderCommand(lineAst, text) {
+  const code = findCodeElement(lineAst);
+  if (!code) return;
+  const commentIndex = shellCommentIndex(text);
+  const command = commentIndex === -1 ? text : text.slice(0, commentIndex);
+  const comment = commentIndex === -1 ? '' : text.slice(commentIndex);
+  code.children = [
+    {
+      type: 'element',
+      tagName: 'span',
+      properties: { className: ['wt-command-text'] },
+      children: [{ type: 'text', value: command }],
+    },
+  ];
+  if (comment) {
+    code.children.push({
+      type: 'element',
+      tagName: 'span',
+      properties: { className: ['wt-terminal-dim'] },
+      children: [{ type: 'text', value: comment }],
+    });
+  }
 }
 
 /**
@@ -104,9 +174,12 @@ export function pluginWorktrunkTerminal() {
     baseStyles: `
       .expressive-code .frame.is-terminal .ec-line.wt-command .code::before {
         content: '$ ';
-        color: var(--sl-color-accent-high);
-        font-weight: 650;
+        color: var(--wt-ink-muted);
         user-select: none;
+      }
+      .expressive-code .frame.is-terminal .wt-command-text {
+        color: var(--wt-copper);
+        font-weight: 550;
       }
       .expressive-code .frame.is-terminal .ec-line.wt-output .code {
         color: var(--sl-color-gray-2);
@@ -125,6 +198,43 @@ export function pluginWorktrunkTerminal() {
       .expressive-code .frame.is-terminal .wt-warning {
         color: var(--sl-color-orange-high);
         font-weight: 650;
+      }
+      .expressive-code .frame.is-terminal .wt-terminal-red {
+        color: var(--wt-terminal-red);
+      }
+      .expressive-code .frame.is-terminal .wt-terminal-green {
+        color: var(--wt-terminal-green);
+      }
+      .expressive-code .frame.is-terminal .wt-terminal-yellow {
+        color: var(--wt-terminal-yellow);
+      }
+      .expressive-code .frame.is-terminal .wt-terminal-blue {
+        color: var(--wt-terminal-blue);
+      }
+      .expressive-code .frame.is-terminal .wt-terminal-magenta {
+        color: var(--wt-terminal-magenta);
+      }
+      .expressive-code .frame.is-terminal .wt-terminal-cyan {
+        color: var(--wt-terminal-cyan);
+      }
+      .expressive-code .frame.is-terminal .wt-terminal-gray {
+        color: var(--wt-ink-muted);
+      }
+      .expressive-code .frame.is-terminal .wt-terminal-gutter {
+        background: var(--wt-terminal-gutter);
+      }
+      .expressive-code .frame.is-terminal .wt-terminal-bold {
+        font-weight: 600;
+      }
+      .expressive-code .frame.is-terminal .wt-terminal-dim {
+        opacity: 0.9;
+      }
+      .expressive-code .frame.is-terminal .wt-terminal-italic {
+        font-style: italic;
+      }
+      .expressive-code .frame.is-terminal .wt-terminal-underline {
+        text-decoration: underline;
+        text-underline-offset: 0.14em;
       }
     `,
     hooks: {
@@ -145,7 +255,22 @@ export function pluginWorktrunkTerminal() {
             copyableLines.add(lineIndex);
           }
         }
-        terminalBlocks.set(codeBlock, { commandLines, copyableLines });
+        const outputLines = lines
+          .map((line, lineIndex) => ({ line, lineIndex }))
+          .filter(({ lineIndex }) => (
+            !commandLines.has(lineIndex) && !copyableLines.has(lineIndex)
+          ));
+        const outputText = outputLines.map(({ line }) => line.text).join('\n').trimEnd();
+        const recordedLines = recordedTerminalBlocks.get(outputText);
+        const recordedByLine = recordedLines?.length === outputLines.length
+          ? new Map(outputLines.map(({ lineIndex }, index) => [lineIndex, recordedLines[index]]))
+          : new Map();
+        terminalBlocks.set(codeBlock, {
+          commandLines,
+          copyableLines,
+          hasOutput,
+          recordedByLine,
+        });
       },
       postprocessRenderedLine({ codeBlock, line, lineIndex, renderData }) {
         const terminal = terminalBlocks.get(codeBlock);
@@ -156,14 +281,25 @@ export function pluginWorktrunkTerminal() {
             ? 'wt-copyable'
             : 'wt-output';
         addClass(renderData.lineAst, className);
-        if (className === 'wt-output') {
-          renderSemanticOutput(renderData.lineAst, line?.text ?? codeBlock.getLines()[lineIndex].text);
+        const text = line?.text ?? codeBlock.getLines()[lineIndex].text;
+        if (className === 'wt-command') {
+          renderCommand(renderData.lineAst, text);
+        } else if (className === 'wt-output') {
+          const rendered = terminal.recordedByLine.has(lineIndex)
+            && renderRecordedOutput(renderData.lineAst, terminal.recordedByLine.get(lineIndex));
+          if (!rendered) renderSemanticOutput(renderData.lineAst, text);
         }
       },
       postprocessRenderedBlock({ codeBlock, renderData }) {
         removeTitlelessHeader(renderData.blockAst);
         const terminal = terminalBlocks.get(codeBlock);
-        if (!terminal) return;
+        if (!terminal) {
+          if (renderData.blockAst.properties?.className?.includes('is-terminal')) {
+            addClass(renderData.blockAst, 'wt-commands-only');
+          }
+          return;
+        }
+        if (!terminal.hasOutput) addClass(renderData.blockAst, 'wt-commands-only');
         if (terminal.commandLines.size === 0 && terminal.copyableLines.size === 0) {
           removeCopyControl(renderData.blockAst);
           return;

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -12,6 +12,13 @@
   --wt-craft: #7e6247;
   --wt-gold-wash: #ead9bb;
   --wt-line: #d9cab7;
+  --wt-terminal-red: #b42318;
+  --wt-terminal-green: #256b4a;
+  --wt-terminal-yellow: #8a5a00;
+  --wt-terminal-blue: #1d4ed8;
+  --wt-terminal-magenta: #7e22ce;
+  --wt-terminal-cyan: #0f6f73;
+  --wt-terminal-gutter: #a8a29e;
   --wt-focus: var(--wt-copper);
   --wt-font-display: 'Newsreader', ui-serif, 'Iowan Old Style', 'Palatino Linotype', Palatino,
     Georgia, serif;
@@ -52,6 +59,13 @@
   --wt-craft: #b99776;
   --wt-gold-wash: #44311e;
   --wt-line: #493a2e;
+  --wt-terminal-red: #f87171;
+  --wt-terminal-green: #6ee7a2;
+  --wt-terminal-yellow: #facc15;
+  --wt-terminal-blue: #93c5fd;
+  --wt-terminal-magenta: #d8b4fe;
+  --wt-terminal-cyan: #67d4d4;
+  --wt-terminal-gutter: #6b7280;
   --sl-color-accent-low: var(--wt-gold-wash);
   --sl-color-accent: var(--wt-copper);
   --sl-color-accent-high: #fcd34d;
@@ -463,6 +477,8 @@ header.header {
 
 /* Code is content, not a simulated application window. */
 .expressive-code .frame {
+  max-width: 100%;
+  min-width: 0;
   margin-block: 1.25rem;
 }
 
@@ -473,6 +489,33 @@ header.header {
   border-radius: 0;
   background-color: var(--wt-scroll-surface);
   box-shadow: none;
+  overscroll-behavior-inline: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+.sl-markdown-content table:not(.cmd-compare):not(:where(.not-content *)) {
+  overscroll-behavior-inline: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (max-width: 42rem) {
+  .expressive-code .frame:not(.is-terminal) pre,
+  .expressive-code .frame.is-terminal.wt-commands-only pre {
+    overflow-x: clip;
+  }
+
+  .expressive-code .frame:not(.is-terminal) .ec-line,
+  .expressive-code .frame:not(.is-terminal) .code,
+  .expressive-code .frame.is-terminal.wt-commands-only .ec-line,
+  .expressive-code .frame.is-terminal.wt-commands-only .code {
+    min-width: 0;
+  }
+
+  .expressive-code .frame:not(.is-terminal) .code,
+  .expressive-code .frame.is-terminal.wt-commands-only .code {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
 }
 
 /* A local cover hides the stationary edge shade once the inline scroll reaches its end. */

--- a/docs/tests/browser-site.test.mjs
+++ b/docs/tests/browser-site.test.mjs
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import path from 'node:path';
+import { after, before, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { webkit } from 'playwright';
+
+const docsRoot = fileURLToPath(new URL('..', import.meta.url));
+const dist = path.join(docsRoot, 'dist');
+const mobileWidths = [320, 393];
+const mimeTypes = new Map([
+  ['.css', 'text/css'],
+  ['.gif', 'image/gif'],
+  ['.html', 'text/html'],
+  ['.js', 'text/javascript'],
+  ['.json', 'application/json'],
+  ['.svg', 'image/svg+xml'],
+  ['.webp', 'image/webp'],
+]);
+
+let server;
+let baseUrl;
+
+before(async () => {
+  server = createServer(async (request, response) => {
+    const url = new URL(request.url, 'http://127.0.0.1');
+    const relative = decodeURIComponent(url.pathname).replace(/^\/+/, '');
+    const file = path.join(dist, relative, url.pathname.endsWith('/') ? 'index.html' : '');
+    try {
+      const body = await readFile(file);
+      response.writeHead(200, { 'content-type': mimeTypes.get(path.extname(file)) ?? 'application/octet-stream' });
+      response.end(body);
+    } catch {
+      response.writeHead(404);
+      response.end('Not found');
+    }
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+});
+
+async function sitemapRoutes() {
+  const sitemap = await readFile(path.join(dist, 'sitemap-0.xml'), 'utf8');
+  return [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/gu)]
+    .map((match) => new URL(match[1]).pathname);
+}
+
+test('mobile pages stay viewport-bound while code remains readable', { timeout: 120_000 }, async () => {
+  const browser = await webkit.launch();
+  const publicRoutes = await sitemapRoutes();
+  let sawScrollableTerminal = false;
+  try {
+    for (const theme of ['light', 'dark']) {
+      for (const width of mobileWidths) {
+        const page = await browser.newPage({ viewport: { width, height: 844 }, colorScheme: theme });
+        for (const route of publicRoutes) {
+          await page.goto(`${baseUrl}${route}`, { waitUntil: 'domcontentloaded' });
+          await page.evaluate((selectedTheme) => {
+            document.documentElement.dataset.theme = selectedTheme;
+          }, theme);
+
+          const layout = await page.evaluate(() => {
+            const rgb = (value) => {
+              const channels = value.match(/[\d.]+/gu).slice(0, 3).map(Number);
+              return value.startsWith('color(srgb')
+                ? channels.map((channel) => channel * 255)
+                : channels;
+            };
+            const luminance = (color) => {
+              const linear = color.map((channel) => {
+                const normalized = channel / 255;
+                return normalized <= 0.04045
+                  ? normalized / 12.92
+                  : ((normalized + 0.055) / 1.055) ** 2.4;
+              });
+              return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+            };
+            const contrast = (foreground, background) => {
+              const lighter = Math.max(luminance(foreground), luminance(background));
+              const darker = Math.min(luminance(foreground), luminance(background));
+              return (lighter + 0.05) / (darker + 0.05);
+            };
+            const dimContrasts = [...document.querySelectorAll('.wt-terminal-dim')].map((span) => {
+              const style = getComputedStyle(span);
+              const foreground = rgb(style.color);
+              const background = rgb(getComputedStyle(span.closest('pre')).backgroundColor);
+              const opacity = Number(style.opacity);
+              const effective = foreground.map((channel, index) => (
+                opacity * channel + (1 - opacity) * background[index]
+              ));
+              return contrast(effective, background);
+            });
+            const fixedTerminal = [...document.querySelectorAll('.frame.is-terminal')]
+              .filter((frame) => frame.querySelector('.wt-output'))
+              .map((frame) => frame.querySelector('pre'))
+              .find((pre) => pre.scrollWidth > pre.clientWidth + 1);
+            if (fixedTerminal) fixedTerminal.scrollLeft = fixedTerminal.scrollWidth;
+            return {
+              viewportWidth: document.documentElement.clientWidth,
+              documentWidth: document.documentElement.scrollWidth,
+              dimContrasts,
+              fixedTerminalScrollLeft: fixedTerminal?.scrollLeft ?? 0,
+              frames: [...document.querySelectorAll('.expressive-code .frame')].map((frame) => {
+                const pre = frame.querySelector('pre');
+                return {
+                  className: frame.className,
+                  managedTerminal: Boolean(
+                    frame.querySelector('.wt-command, .wt-output, .wt-copyable'),
+                  ),
+                  hasOutput: Boolean(frame.querySelector('.wt-output')),
+                  frameLeft: frame.getBoundingClientRect().left,
+                  frameRight: frame.getBoundingClientRect().right,
+                  preClientWidth: pre?.clientWidth ?? 0,
+                  preScrollWidth: pre?.scrollWidth ?? 0,
+                };
+              }),
+            };
+          });
+
+          assert.equal(
+            layout.documentWidth,
+            layout.viewportWidth,
+            `${theme} ${width}px ${route} widens the document`,
+          );
+          for (const ratio of layout.dimContrasts) {
+            assert.ok(
+              ratio >= 4.5,
+              `${theme} ${width}px ${route} dim text contrast is ${ratio.toFixed(2)}:1`,
+            );
+          }
+          for (const frame of layout.frames) {
+            assert.ok(frame.frameLeft >= -1, `${theme} ${width}px ${route} code starts offscreen`);
+            assert.ok(
+              frame.frameRight <= layout.viewportWidth + 1,
+              `${theme} ${width}px ${route} code ends offscreen`,
+            );
+            const terminal = frame.className.includes('is-terminal');
+            const commandsOnly = frame.className.includes('wt-commands-only');
+            if (terminal) {
+              assert.equal(
+                commandsOnly,
+                !frame.hasOutput,
+                `${theme} ${width}px ${route} misclassifies a terminal block`,
+              );
+            }
+            const wraps = !terminal || commandsOnly;
+            if (wraps) {
+              assert.ok(
+                frame.preScrollWidth <= frame.preClientWidth + 1,
+                `${theme} ${width}px ${route} wrappable code still scrolls horizontally`,
+              );
+            }
+          }
+
+          if (layout.fixedTerminalScrollLeft > 0) sawScrollableTerminal = true;
+
+          await page.evaluate(() => window.scrollTo({ left: 100, top: 0 }));
+          assert.equal(await page.evaluate(() => window.scrollX), 0, `${theme} ${width}px ${route} pans sideways`);
+        }
+        await page.close();
+      }
+    }
+    assert.ok(sawScrollableTerminal, 'expected a fixed terminal table to retain internal scrolling');
+  } finally {
+    await browser.close();
+  }
+});

--- a/docs/tests/built-site.test.mjs
+++ b/docs/tests/built-site.test.mjs
@@ -170,8 +170,8 @@ test('build preserves the public route contract', async () => {
   assert.ok(comparison, 'homepage is missing the command comparison table');
   assert.equal(comparison.match(/<td data-label="Worktrunk">/g)?.length, 4);
   assert.equal(comparison.match(/<td data-label="Plain git">/g)?.length, 4);
-  assert.match(homepage, /class="wt-positive"/);
-  assert.match(homepage, /class="wt-negative"/);
+  assert.match(homepage, /class="wt-terminal-green"/);
+  assert.match(homepage, /class="wt-terminal-red"/);
   const switchPage = await readFile(routeFile('/switch/'), 'utf8');
   assert.match(switchPage, /<nav aria-labelledby="starlight__on-this-page">/);
   assert.match(
@@ -183,6 +183,17 @@ test('build preserves the public route contract', async () => {
   const listPage = await readFile(routeFile('/list/'), 'utf8');
   assert.match(listPage, /href="https:\/\/github\.com\/max-sixty\/worktrunk\/edit\/main\/docs\/src\/content\/docs\/list\.md"/);
   assert.doesNotMatch(listPage, /docs\/src\/content\/docs\/src\/content\/docs/);
+  assert.match(listPage, /<span class="wt-terminal-green">\+54<\/span>/);
+  assert.match(listPage, /<span class="wt-terminal-red">-5<\/span>/);
+  assert.match(listPage, /<span class="wt-terminal-blue wt-terminal-dim">#412<\/span>/);
+  assert.match(listPage, /<span class="wt-command-text">wt list<\/span>/);
+
+  const llmCommitsPage = await readFile(routeFile('/llm-commits/'), 'utf8');
+  assert.match(llmCommitsPage, /<span class="wt-terminal-cyan">◎<\/span>/);
+  assert.match(
+    llmCommitsPage,
+    /<span class="wt-terminal-bold">feat\(validation\): add input validation utilities<\/span>/,
+  );
 
   const configPage = await readFile(routeFile('/config/'), 'utf8');
   const configToc = configPage.match(

--- a/docs/tests/plugins.test.mjs
+++ b/docs/tests/plugins.test.mjs
@@ -299,6 +299,26 @@ test('console output and its blank lines stay out of copied commands', () => {
   assert.equal(copyButton.properties['data-code'], 'wt list\u007f# shell comment');
 });
 
+test('shell snippets use the command-only terminal classifier', () => {
+  const codeBlock = { language: 'bash', getLines: () => [] };
+  const blockAst = {
+    type: 'element',
+    tagName: 'figure',
+    properties: { className: ['frame', 'is-terminal'] },
+    children: [],
+  };
+  const plugin = pluginWorktrunkTerminal();
+
+  plugin.hooks.preprocessCode({ codeBlock });
+  plugin.hooks.postprocessRenderedBlock({ codeBlock, renderData: { blockAst } });
+
+  assert.deepEqual(blockAst.properties.className, [
+    'frame',
+    'is-terminal',
+    'wt-commands-only',
+  ]);
+});
+
 test('console output retains state-color semantics without ANSI in Markdown', () => {
   assert.deepEqual(
     semanticOutputSegments('@ feat  +54  -5  ↑4  ↓1  ⇡3  ?  ✓ done'),
@@ -326,12 +346,65 @@ test('console output retains state-color semantics without ANSI in Markdown', ()
     [{ text: '[unoptimized + debuginfo] Allow and remember?' }],
   );
   assert.deepEqual(
-    semanticOutputSegments('@ feat  +   ↑'),
-    [
-      { text: '@ feat  ' },
-      { text: '+', tone: 'positive' },
-      { text: '   ' },
-      { text: '↑', tone: 'positive' },
-    ],
+    semanticOutputSegments('release-5 v1+2 port -3000'),
+    [{ text: 'release-5 v1+2 port -3000' }],
   );
+  assert.deepEqual(
+    semanticOutputSegments('@ feat  +   ↑'),
+    [{ text: '@ feat  +   ↑' }],
+  );
+});
+
+test('console commands distinguish commands from trailing shell comments', () => {
+  const lines = [
+    '$ wt switch "#412" # inspect the PR',
+    "$ printf '%s' '# literal'",
+  ].map((text) => ({
+    text,
+    editText(start, end, replacement) {
+      this.text = this.text.slice(0, start) + replacement + this.text.slice(end);
+    },
+  }));
+  const codeBlock = { language: 'console', getLines: () => lines };
+  const plugin = pluginWorktrunkTerminal();
+  plugin.hooks.preprocessCode({ codeBlock });
+
+  const rendered = lines.map((line, lineIndex) => {
+    const code = {
+      type: 'element',
+      tagName: 'div',
+      properties: { className: ['code'] },
+      children: [{ type: 'text', value: line.text }],
+    };
+    const renderData = {
+      lineAst: { type: 'element', tagName: 'div', properties: {}, children: [code] },
+    };
+    plugin.hooks.postprocessRenderedLine({ codeBlock, line, lineIndex, renderData });
+    return code.children;
+  });
+
+  assert.deepEqual(rendered, [
+    [
+      {
+        type: 'element',
+        tagName: 'span',
+        properties: { className: ['wt-command-text'] },
+        children: [{ type: 'text', value: 'wt switch "#412" ' }],
+      },
+      {
+        type: 'element',
+        tagName: 'span',
+        properties: { className: ['wt-terminal-dim'] },
+        children: [{ type: 'text', value: '# inspect the PR' }],
+      },
+    ],
+    [
+      {
+        type: 'element',
+        tagName: 'span',
+        properties: { className: ['wt-command-text'] },
+        children: [{ type: 'text', value: "printf '%s' '# literal'" }],
+      },
+    ],
+  ]);
 });

--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -22,8 +22,10 @@
 
 use crate::common::wt_command;
 use ansi_str::AnsiStr;
+use ansi_to_tui::IntoText;
+use ratatui::style::{Color, Modifier, Style};
 use regex::Regex;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -455,36 +457,50 @@ static COMMAND_PLACEHOLDER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
         .unwrap()
 });
 
-/// Map commands to their snapshot files for help page expansion
+/// Snapshot-backed command examples shared by Markdown generation and the
+/// website's ANSI-style manifest.
+const COMMAND_SNAPSHOTS: &[(&str, &str)] = &[
+    (
+        "wt list",
+        "integration__integration_tests__list__readme_example_list.snap",
+    ),
+    (
+        "wt list --full",
+        "integration__integration_tests__list__readme_example_list_full.snap",
+    ),
+    (
+        "wt list --branches --full",
+        "integration__integration_tests__list__readme_example_list_branches.snap",
+    ),
+    (
+        "wt list (markers)",
+        "integration__integration_tests__list__readme_example_list_marker.snap",
+    ),
+    // Docs-page example snapshots drive the static command-output blocks on
+    // pages otherwise dominated by GIFs. See the convention in merge.rs.
+    (
+        "wt merge (docs-example)",
+        "integration__integration_tests__merge__docs_merge_pre_merge_hook.snap",
+    ),
+    (
+        "wt step commit (docs-example)",
+        "integration__integration_tests__merge__docs_step_commit_llm.snap",
+    ),
+    (
+        "wt remove (docs-example)",
+        "integration__integration_tests__remove__docs_remove_pre_remove_hook.snap",
+    ),
+    (
+        "wt hook pre-merge (docs-example)",
+        "integration__integration_tests__user_hooks__docs_hook_pre_merge.snap",
+    ),
+];
+
+/// Map commands to their snapshot files for help page expansion.
 fn command_to_snapshot(command: &str) -> Option<&'static str> {
-    match command {
-        "wt list" => Some("integration__integration_tests__list__readme_example_list.snap"),
-        "wt list --full" => {
-            Some("integration__integration_tests__list__readme_example_list_full.snap")
-        }
-        "wt list --branches --full" => {
-            Some("integration__integration_tests__list__readme_example_list_branches.snap")
-        }
-        "wt list (markers)" => {
-            Some("integration__integration_tests__list__readme_example_list_marker.snap")
-        }
-        // Docs-page example snapshots — drive the static command-output blocks
-        // on pages otherwise dominated by GIFs. See comment in merge.rs test
-        // section for the convention.
-        "wt merge (docs-example)" => {
-            Some("integration__integration_tests__merge__docs_merge_pre_merge_hook.snap")
-        }
-        "wt step commit (docs-example)" => {
-            Some("integration__integration_tests__merge__docs_step_commit_llm.snap")
-        }
-        "wt remove (docs-example)" => {
-            Some("integration__integration_tests__remove__docs_remove_pre_remove_hook.snap")
-        }
-        "wt hook pre-merge (docs-example)" => {
-            Some("integration__integration_tests__user_hooks__docs_hook_pre_merge.snap")
-        }
-        _ => None,
-    }
+    COMMAND_SNAPSHOTS
+        .iter()
+        .find_map(|(candidate, snapshot)| (*candidate == command).then_some(*snapshot))
 }
 
 /// Expand command placeholders in help page content into rendered snapshot blocks.
@@ -568,6 +584,176 @@ fn parse_snapshot_content(content: &str) -> String {
     let content = replace_placeholders(&content);
     let content = literal_to_escape(&content);
     content.ansi_strip().into_owned()
+}
+
+/// CSS class for the semantic ANSI foreground carried by a snapshot span.
+fn terminal_color_class(color: Color) -> Result<Option<&'static str>, String> {
+    match color {
+        Color::Red | Color::LightRed => Ok(Some("wt-terminal-red")),
+        Color::Green | Color::LightGreen => Ok(Some("wt-terminal-green")),
+        Color::Yellow | Color::LightYellow => Ok(Some("wt-terminal-yellow")),
+        Color::Blue | Color::LightBlue => Ok(Some("wt-terminal-blue")),
+        Color::Magenta | Color::LightMagenta => Ok(Some("wt-terminal-magenta")),
+        Color::Cyan | Color::LightCyan => Ok(Some("wt-terminal-cyan")),
+        Color::DarkGray | Color::Gray => Ok(Some("wt-terminal-gray")),
+        Color::Reset => Ok(None),
+        Color::Black | Color::White | Color::Rgb(..) | Color::Indexed(_) => {
+            Err(format!("unsupported ANSI foreground color {color:?}"))
+        }
+    }
+}
+
+/// CSS class for the bright execution gutter rendered by Worktrunk output.
+fn terminal_background_class(color: Color) -> Result<Option<&'static str>, String> {
+    match color {
+        Color::Gray | Color::White => Ok(Some("wt-terminal-gutter")),
+        Color::Reset => Ok(None),
+        Color::Black
+        | Color::Red
+        | Color::Green
+        | Color::Yellow
+        | Color::Blue
+        | Color::Magenta
+        | Color::Cyan
+        | Color::DarkGray
+        | Color::LightRed
+        | Color::LightGreen
+        | Color::LightYellow
+        | Color::LightBlue
+        | Color::LightMagenta
+        | Color::LightCyan
+        | Color::Rgb(..)
+        | Color::Indexed(_) => Err(format!("unsupported ANSI background color {color:?}")),
+    }
+}
+
+fn terminal_style_classes(style: Style) -> Result<Vec<String>, String> {
+    let mut classes = Vec::new();
+    if let Some(color) = style.fg
+        && let Some(class) = terminal_color_class(color)?
+    {
+        classes.push(class.to_string());
+    }
+    if style.add_modifier.contains(Modifier::BOLD) {
+        classes.push("wt-terminal-bold".to_string());
+    }
+    if style.add_modifier.contains(Modifier::DIM) {
+        classes.push("wt-terminal-dim".to_string());
+    }
+    if style.add_modifier.contains(Modifier::ITALIC) {
+        classes.push("wt-terminal-italic".to_string());
+    }
+    if style.add_modifier.contains(Modifier::UNDERLINED) {
+        classes.push("wt-terminal-underline".to_string());
+    }
+    if let Some(color) = style.bg
+        && let Some(class) = terminal_background_class(color)?
+    {
+        classes.push(class.to_string());
+    }
+    Ok(classes)
+}
+
+/// Parse one snapshot's ANSI output into the span data the website renderer
+/// consumes. The reconstructed visible text must equal the portable Markdown
+/// generated from the same snapshot, which prevents style and content from
+/// drifting into two parallel examples.
+fn styled_snapshot_lines(content: &str) -> Result<(String, serde_json::Value), String> {
+    let raw = parse_snapshot_raw(content);
+    let raw = replace_placeholders(&raw);
+    let ansi = literal_to_escape(&raw);
+    let parsed = ansi
+        .as_str()
+        .into_text()
+        .map_err(|error| format!("ANSI parsing failed: {error}"))?;
+    let plain = trim_lines(&parse_snapshot_content(content));
+    let expected_lines: Vec<&str> = if plain.is_empty() {
+        Vec::new()
+    } else {
+        plain.split('\n').collect()
+    };
+
+    if parsed.lines.len() < expected_lines.len() {
+        return Err(format!(
+            "ANSI parser returned {} line(s), expected {}",
+            parsed.lines.len(),
+            expected_lines.len()
+        ));
+    }
+
+    let mut rendered_lines = Vec::with_capacity(expected_lines.len());
+    for (line_index, expected) in expected_lines.into_iter().enumerate() {
+        let line = &parsed.lines[line_index];
+        let mut segments: Vec<(String, Vec<String>)> = Vec::new();
+        for span in &line.spans {
+            if span.content.is_empty() {
+                continue;
+            }
+            let classes = terminal_style_classes(parsed.style.patch(line.style).patch(span.style))
+                .map_err(|error| format!("styled line {}: {error}", line_index + 1))?;
+            if let Some((text, previous_classes)) = segments.last_mut()
+                && *previous_classes == classes
+            {
+                text.push_str(&span.content);
+            } else {
+                segments.push((span.content.to_string(), classes));
+            }
+        }
+
+        while let Some((text, _)) = segments.last_mut() {
+            let trimmed = text.trim_end().to_string();
+            if trimmed.is_empty() {
+                segments.pop();
+            } else {
+                *text = trimmed;
+                break;
+            }
+        }
+
+        let actual = segments
+            .iter()
+            .map(|(text, _)| text.as_str())
+            .collect::<String>();
+        if actual != expected {
+            return Err(format!(
+                "styled line {} differs from portable text\nexpected: {expected:?}\nactual:   {actual:?}",
+                line_index + 1
+            ));
+        }
+
+        rendered_lines.push(serde_json::Value::Array(
+            segments
+                .into_iter()
+                .map(|(text, classes)| serde_json::json!({ "text": text, "classes": classes }))
+                .collect(),
+        ));
+    }
+
+    Ok((plain, serde_json::Value::Array(rendered_lines)))
+}
+
+#[test]
+fn test_styled_snapshot_lines_preserve_text_and_ansi_roles() {
+    let (plain, lines) = styled_snapshot_lines(
+        "\x1b[107m \x1b[0m \x1b[1mBranch\x1b[0m  \x1b[32m+2\x1b[0m  \x1b[2m\x1b[34m#42\x1b[0m",
+    )
+    .unwrap();
+    assert_eq!(plain, "  Branch  +2  #42");
+    assert_eq!(
+        lines,
+        serde_json::json!([[
+            { "text": " ", "classes": ["wt-terminal-gutter"] },
+            { "text": " ", "classes": [] },
+            { "text": "Branch", "classes": ["wt-terminal-bold"] },
+            { "text": "  ", "classes": [] },
+            { "text": "+2", "classes": ["wt-terminal-green"] },
+            { "text": "  ", "classes": [] },
+            { "text": "#42", "classes": ["wt-terminal-blue", "wt-terminal-dim"] }
+        ]])
+    );
+
+    let error = styled_snapshot_lines("\x1b[38;2;1;2;3mcustom\x1b[0m").unwrap_err();
+    assert!(error.contains("unsupported ANSI foreground color Rgb(1, 2, 3)"));
 }
 
 /// Get help output for a command
@@ -1544,6 +1730,14 @@ const COMMAND_PAGES: &[&str] = &[
     "switch", "list", "merge", "remove", "config", "step", "hook",
 ];
 
+/// Hand-edited site pages whose snapshot markers are refreshed by this test.
+const STANDALONE_DOC_FILES: &[&str] = &[
+    "docs/src/content/docs/worktrunk.md",
+    "docs/src/content/docs/claude-code.md",
+    "docs/src/content/docs/tips-patterns.md",
+    "docs/src/content/docs/llm-commits.md",
+];
+
 /// Write `expected` to `path` and record `rel_path` in `updated`. Creates
 /// parent directories as needed. Panics on I/O failure — these are test-time
 /// syncs, so any write error should abort the run.
@@ -2219,6 +2413,92 @@ fn sync_json_schema(project_root: &Path) -> (Vec<String>, Vec<String>) {
     (errors, updated_files)
 }
 
+/// Generate the site-only style manifest from the same ANSI snapshots that
+/// populate the portable Markdown examples. Expressive Code receives plain
+/// text by design; this sidecar lets it restore the CLI's semantic styling
+/// without putting escape sequences or renderer-specific HTML in Markdown.
+fn sync_terminal_style_manifest(project_root: &Path) -> (Vec<String>, Vec<String>) {
+    let mut errors = Vec::new();
+    let mut updated_files = Vec::new();
+    let snapshots_dir = project_root.join("tests/snapshots");
+    let mut snapshot_paths = BTreeSet::new();
+    let mut blocks: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+
+    snapshot_paths.extend(
+        COMMAND_SNAPSHOTS
+            .iter()
+            .map(|(_, snapshot_name)| snapshots_dir.join(snapshot_name)),
+    );
+    for doc_file in STANDALONE_DOC_FILES {
+        let doc_path = project_root.join(doc_file);
+        let content = match fs::read_to_string(&doc_path) {
+            Ok(content) => content,
+            Err(error) => {
+                errors.push(format!("Failed to read {}: {error}", doc_path.display()));
+                continue;
+            }
+        };
+        snapshot_paths.extend(
+            DOCS_SNAPSHOT_MARKER_PATTERN
+                .captures_iter(&content)
+                .map(|captures| project_root.join(captures.get(1).unwrap().as_str())),
+        );
+    }
+
+    for snapshot_path in snapshot_paths {
+        let raw = match fs::read_to_string(&snapshot_path) {
+            Ok(raw) => raw,
+            Err(error) => {
+                errors.push(format!(
+                    "Failed to read {}: {error}",
+                    snapshot_path.display()
+                ));
+                continue;
+            }
+        };
+        let (plain, lines) = match styled_snapshot_lines(&raw) {
+            Ok(styled) => styled,
+            Err(error) => {
+                errors.push(format!("{}: {error}", snapshot_path.display()));
+                continue;
+            }
+        };
+        if plain.is_empty() {
+            continue;
+        }
+        if let Some(existing) = blocks.insert(plain.clone(), lines.clone())
+            && existing != lines
+        {
+            errors.push(format!(
+                "{}: duplicate portable output carries different ANSI styling",
+                snapshot_path.display()
+            ));
+        }
+    }
+
+    if !errors.is_empty() {
+        return (errors, updated_files);
+    }
+
+    let generated = format!(
+        "{}\n",
+        serde_json::to_string_pretty(
+            &blocks
+                .into_iter()
+                .map(|(plain, lines)| serde_json::json!({ "plain": plain, "lines": lines }))
+                .collect::<Vec<_>>()
+        )
+        .unwrap()
+    );
+    let rel_path = "docs/src/generated/terminal-styles.json";
+    let dst = project_root.join(rel_path);
+    if fs::read_to_string(&dst).unwrap_or_default() != generated {
+        write_tracked(&dst, &generated, rel_path, &mut updated_files);
+    }
+
+    (errors, updated_files)
+}
+
 /// Generate `docs/public/llms.txt` from the Starlight content collection,
 /// following the llms.txt spec (https://llmstxt.org/): H1, blockquote summary,
 /// optional intro prose, H2 section headings with bulleted link lists.
@@ -2415,15 +2695,9 @@ fn test_docs_are_in_sync() {
 
     // Step 2: Sync standalone docs files from snapshots.
     // README extraction in step 5 reads these, so they must be current first.
-    let standalone_doc_files = [
-        "docs/src/content/docs/worktrunk.md",
-        "docs/src/content/docs/claude-code.md",
-        "docs/src/content/docs/tips-patterns.md",
-        "docs/src/content/docs/llm-commits.md",
-    ];
     let mut docs_errors: Vec<String> = Vec::new();
     let mut docs_files: Vec<String> = Vec::new();
-    for doc_file in standalone_doc_files {
+    for doc_file in STANDALONE_DOC_FILES {
         let doc_path = project_root.join(doc_file);
         match sync_docs_snapshots(&doc_path, project_root) {
             Ok(updated) => {
@@ -2435,6 +2709,15 @@ fn test_docs_are_in_sync() {
         }
     }
     tag("standalone docs", docs_errors, docs_files);
+
+    // Step 2b: Preserve the ANSI semantics of snapshot-backed examples in a
+    // site-only manifest while the Markdown remains portable plain text.
+    let (terminal_style_errors, terminal_style_files) = sync_terminal_style_manifest(project_root);
+    tag(
+        "terminal styles",
+        terminal_style_errors,
+        terminal_style_files,
+    );
 
     // Step 3: Sync skill files (Starlight Markdown → skills/*)
     let (skill_errors, skill_files) = sync_skill_files(project_root);


### PR DESCRIPTION
## Summary

- re-record and publish both mobile homepage demos with restored ANSI colors
- preserve exact ANSI roles in every snapshot-backed website terminal while keeping Markdown portable
- wrap source and command snippets on mobile, contain fixed terminal tables, and add real WebKit layout and contrast regressions

The corrected GIFs are already published in `max-sixty/worktrunk-assets` at `4de7bde`.

## Testing

- `cargo run -- hook pre-merge --yes` (4,721 tests passed, 1 skipped)
- `npm --prefix docs run check`
- `npm --prefix docs test`
- `npm --prefix docs run build`
- `npm --prefix docs run test:site`
- independent frame review of both mobile GIF themes
- independent architecture, systematic, and adversarial reviews

Closes #3930
Closes #3931

> _This was written by Codex on behalf of max-sixty._
