### PR TITLE
Soften explicit command approval prompts

### DIFF
--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -25,7 +25,7 @@ use color_print::cformat;
 use worktrunk::config::{Approvals, require_approvals_path};
 use worktrunk::git::{GitError, HookType};
 use worktrunk::styling::{
-    INFO_SYMBOL, WARNING_SYMBOL, eprint, eprintln, hint_message, info_message, prompt_message,
+    INFO_SYMBOL, WARNING_SYMBOL, eprint, eprintln, format_heading, hint_message, prompt_message,
     stderr, warning_message,
 };
 
@@ -124,21 +124,24 @@ fn print_command_batch(header: impl std::fmt::Display, commands: &[&ApprovableCo
 
 /// The batch `wt config approvals add --yes` is about to trust. Nothing is
 /// being asked, but the batch still prints: it is the record of what an
-/// unattended run just approved. Lives beside [`prompt_for_batch_approval`]
+/// unattended run just approved. Lives beside [`prompt_for_batch_review`]
 /// so the two headers stay parallel.
 pub fn announce_batch_approval(commands: &[&ApprovableCommand], project_id: &str) {
     let project_name = display_project_name(project_id);
     let count = commands.len();
     let plural = if count == 1 { "" } else { "s" };
     print_command_batch(
-        info_message(cformat!(
-            "Approving <bold>{count}</> command{plural} for <bold>{project_name}</> (--yes):"
-        )),
+        format_heading(
+            &cformat!(
+                "Approving <bold>{count}</> command{plural} for <bold>{project_name}</> (--yes):"
+            ),
+            None,
+        ),
         commands,
     );
 }
 
-pub fn prompt_for_batch_approval(
+fn prompt_for_batch_approval(
     commands: &[&ApprovableCommand],
     project_id: &str,
 ) -> anyhow::Result<bool> {
@@ -162,9 +165,10 @@ pub fn prompt_for_batch_review(
     let count = commands.len();
     let plural = if count == 1 { "" } else { "s" };
 
-    let header = info_message(cformat!(
-        "Review <bold>{count}</> command{plural} for <bold>{project_name}</>:"
-    ));
+    let header = format_heading(
+        &cformat!("Review <bold>{count}</> command{plural} for <bold>{project_name}</>:"),
+        None,
+    );
     prompt_for_batch_approval_with_header(commands, header)
 }
 

--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -25,8 +25,8 @@ use color_print::cformat;
 use worktrunk::config::{Approvals, require_approvals_path};
 use worktrunk::git::{GitError, HookType};
 use worktrunk::styling::{
-    INFO_SYMBOL, WARNING_SYMBOL, eprint, eprintln, hint_message, prompt_message, stderr,
-    warning_message,
+    INFO_SYMBOL, WARNING_SYMBOL, eprint, eprintln, hint_message, info_message, prompt_message,
+    stderr, warning_message,
 };
 
 use super::hook_filter::{HookSource, ParsedFilter};
@@ -113,7 +113,7 @@ fn display_project_name(project_id: &str) -> &str {
 
 /// The batch as the user sees it: a header, then each command's label and its
 /// template. Shared by the prompt and by `--yes` on `wt config approvals add`.
-fn print_command_batch(header: &str, commands: &[&ApprovableCommand]) {
+fn print_command_batch(header: impl std::fmt::Display, commands: &[&ApprovableCommand]) {
     eprintln!("{header}");
     for cmd in commands {
         // Uses INFO_SYMBOL (○) since this is a preview, not active execution
@@ -131,9 +131,9 @@ pub fn announce_batch_approval(commands: &[&ApprovableCommand], project_id: &str
     let count = commands.len();
     let plural = if count == 1 { "" } else { "s" };
     print_command_batch(
-        &cformat!(
-            "{WARNING_SYMBOL} <yellow>Approving <bold>{count}</> command{plural} for <bold>{project_name}</> (--yes):</>"
-        ),
+        info_message(cformat!(
+            "Approving <bold>{count}</> command{plural} for <bold>{project_name}</> (--yes):"
+        )),
         commands,
     );
 }
@@ -146,12 +146,33 @@ pub fn prompt_for_batch_approval(
     let count = commands.len();
     let plural = if count == 1 { "" } else { "s" };
 
-    print_command_batch(
-        &cformat!(
-            "{WARNING_SYMBOL} <yellow><bold>{project_name}</> needs approval to execute <bold>{count}</> command{plural}:</>"
-        ),
-        commands,
+    let header = cformat!(
+        "{WARNING_SYMBOL} <yellow><bold>{project_name}</> needs approval to execute <bold>{count}</> command{plural}:</>"
     );
+    prompt_for_batch_approval_with_header(commands, header)
+}
+
+/// Prompt used by `wt config approvals add`, where reviewing approvals is the
+/// command's expected workflow rather than an interruption to another action.
+pub fn prompt_for_batch_review(
+    commands: &[&ApprovableCommand],
+    project_id: &str,
+) -> anyhow::Result<bool> {
+    let project_name = display_project_name(project_id);
+    let count = commands.len();
+    let plural = if count == 1 { "" } else { "s" };
+
+    let header = info_message(cformat!(
+        "Review <bold>{count}</> command{plural} for <bold>{project_name}</>:"
+    ));
+    prompt_for_batch_approval_with_header(commands, header)
+}
+
+fn prompt_for_batch_approval_with_header(
+    commands: &[&ApprovableCommand],
+    header: impl std::fmt::Display,
+) -> anyhow::Result<bool> {
+    print_command_batch(header, commands);
 
     // Check if stdin is a TTY before attempting to prompt
     // This happens AFTER showing the commands so they appear in CI/CD logs

--- a/src/commands/config/approvals.rs
+++ b/src/commands/config/approvals.rs
@@ -19,7 +19,7 @@ use worktrunk::styling::{
 };
 
 use crate::cli::SwitchFormat;
-use crate::commands::command_approval::{announce_batch_approval, prompt_for_batch_approval};
+use crate::commands::command_approval::{announce_batch_approval, prompt_for_batch_review};
 use crate::commands::project_config::{
     ApprovableCommand, collect_commands_for_aliases, collect_commands_for_hooks,
 };
@@ -236,7 +236,7 @@ pub fn add_approvals(show_all: bool, yes: bool) -> anyhow::Result<()> {
         announce_batch_approval(&batch, &project_id);
         true
     } else {
-        prompt_for_batch_approval(&batch, &project_id)?
+        prompt_for_batch_review(&batch, &project_id)?
     };
 
     if !approved {

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
@@ -61,7 +61,7 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
+[2m○[22m Review [1m1[22m command for [1morigin[22m:
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
@@ -61,7 +61,7 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Review [1m1[22m command for [1morigin[22m:
+[36mReview [1m1[22m command for [1morigin[22m:[39m
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_bare_repo_config_in_primary_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_bare_repo_config_in_primary_worktree.snap
@@ -52,7 +52,7 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-▲ repo needs approval to execute 1 command:
+○ Review 1 command for repo:
 ○ pre-start:
   echo 'hello'
 ✗ Cannot prompt for approval in non-interactive environment

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_bare_repo_config_in_primary_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_bare_repo_config_in_primary_worktree.snap
@@ -52,7 +52,7 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-○ Review 1 command for repo:
+Review 1 command for repo:
 ○ pre-start:
   echo 'hello'
 ✗ Cannot prompt for approval in non-interactive environment

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_includes_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_includes_aliases.snap
@@ -60,7 +60,7 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
+[2m○[22m Review [1m1[22m command for [1morigin[22m:
 [2m○[22m alias [1mdeploy[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m deploying [0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_includes_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_includes_aliases.snap
@@ -60,7 +60,7 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Review [1m1[22m command for [1morigin[22m:
+[36mReview [1m1[22m command for [1morigin[22m:[39m
 [2m○[22m alias [1mdeploy[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m deploying [0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_yes.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_yes.snap
@@ -61,7 +61,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mApproving [1m2[22m commands for [1mrepo[22m (--yes):[39m
+[2m○[22m Approving [1m2[22m commands for [1mrepo[22m (--yes):
 [2m○[22m pre-merge:
 [107m [0m [2m[0m[2m[34mcargo[0m[2m test[0m
 [2m○[22m alias [1mdeploy[22m:

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_yes.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_yes.snap
@@ -61,7 +61,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Approving [1m2[22m commands for [1mrepo[22m (--yes):
+[36mApproving [1m2[22m commands for [1mrepo[22m (--yes):[39m
 [2m○[22m pre-merge:
 [107m [0m [2m[0m[2m[34mcargo[0m[2m test[0m
 [2m○[22m alias [1mdeploy[22m:


### PR DESCRIPTION
Use a neutral heading when `wt config approvals add` reviews or records commands. Approval prompts that interrupt command execution keep the warning.

> _This was written by Codex on behalf of max-sixty_
