### PR TITLE
Scope the branch-inventory staleness contract to membership

### DIFF
--- a/src/git/repository/branches.rs
+++ b/src/git/repository/branches.rs
@@ -112,7 +112,9 @@ impl Repository {
     /// needs a current SHA for a ref must resolve through a `RefSnapshot`
     /// captured at the moment of read, not through this inventory. The
     /// inventory itself is used for branch listing and upstream-tracking
-    /// metadata, both of which are stable for the duration of a command.
+    /// metadata, stable for the duration of a command unless that command
+    /// runs a hook: a hook that adds, deletes, or renames a branch leaves
+    /// the membership stale too, not just the SHAs.
     pub fn local_branches(&self) -> anyhow::Result<&[LocalBranch]> {
         Ok(self.local_branch_inventory()?.entries())
     }

--- a/src/git/repository/branches.rs
+++ b/src/git/repository/branches.rs
@@ -112,9 +112,10 @@ impl Repository {
     /// needs a current SHA for a ref must resolve through a `RefSnapshot`
     /// captured at the moment of read, not through this inventory. The
     /// inventory itself is used for branch listing and upstream-tracking
-    /// metadata, stable for the duration of a command unless that command
-    /// runs a hook: a hook that adds, deletes, or renames a branch leaves
-    /// the membership stale too, not just the SHAs.
+    /// metadata, stable for the duration of a command that runs no hook.
+    /// A hook runs inside the command, so one that touches refs leaves the
+    /// rest of the inventory stale too — which branches are in it, and where
+    /// each one's upstream points.
     pub fn local_branches(&self) -> anyhow::Result<&[LocalBranch]> {
         Ok(self.local_branch_inventory()?.entries())
     }

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -322,8 +322,8 @@ pub(super) struct RepoCache {
     /// **The `commit_sha` field on each entry is a snapshot at scan time.**
     /// Code that needs a current SHA must resolve through a [`RefSnapshot`]
     /// captured at the moment the read happens — not through this inventory.
-    /// The inventory is used for branch-name listing and upstream-tracking
-    /// metadata, both of which are stable for the duration of a command.
+    /// Everything else the inventory holds goes stale the same way once the
+    /// command runs a hook; [`Repository::local_branches`] owns that contract.
     pub(super) local_branches: OnceCell<branches::LocalBranchInventory>,
     /// Remote-tracking branch inventory: one `git for-each-ref refs/remotes/`
     /// scan, cached for the lifetime of the repository. Sorted by most recent


### PR DESCRIPTION
`Repository::local_branches` scans `refs/heads/` once and caches the result for the
lifetime of the `Repository`. Its docstring already scoped a staleness contract to
`commit_sha` — "a snapshot at scan time", resolve through a `RefSnapshot` instead — but
then said of the inventory itself:

> The inventory itself is used for branch listing and upstream-tracking metadata, both of
> which are stable for the duration of a command.

That holds only for a command that runs no hooks. Hooks run *inside* a command, so a
`pre-switch` or `pre-remove` hook that adds, deletes, or renames a branch leaves the
cached membership stale, not just the SHAs.

## Where it shows up

The behaviour is intended — one scan per command is the point — but the docstring said
membership was stable, which sends a reader looking for a bug when they hit it. Two
consumers see it:

- `detect_branch_namespace_conflict` (`src/commands/worktree/switch.rs`) reads the
  inventory to name the branch blocking a `git worktree add -b`. A hook that deletes
  `feature/nested` and creates `feature` in the same command yields "collides with
  existing branch feature/nested" where "already exists" is the truth. Cosmetic.
- `wt step prune` iterates `all_branches()` to choose what to prune, so a branch created
  by a hook mid-command isn't considered. Conservative, but a selection difference rather
  than a message one — which is why the note says membership rather than "messages can be
  wrong".

## What this changes

The docstring, and nothing else. No behaviour change, no new test.

This came out of reviewing #3984, where the same staleness was flagged against the
namespace-conflict mapping. A doc entry was considered and dropped: the FAQ's questions
sit a level up from one cache's staleness, and there's no broader question this is a
detail of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
