### PR TITLE
Collapse the remaining generated mirrors in PR diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,10 +9,22 @@ skills/worktrunk/reference/*.md linguist-generated=true
 skills/worktrunk/reference/README.md linguist-generated=false
 skills/worktrunk/reference/shell-integration.md linguist-generated=false
 skills/worktrunk/reference/troubleshooting.md linguist-generated=false
+# The plugin skills tree is a real-file mirror of repo-root skills/, rewritten by
+# `test_docs_are_in_sync`'s `sync_plugin_skills_mirror` stage. Nothing here is
+# primary, including its copies of the skill-only pages exempted above.
+plugins/worktrunk/skills/** linguist-generated=true
 docs/public/*.md linguist-generated=true
 docs/public/llms.txt linguist-generated=true
 docs/public/.well-known/agent-skills/index.json linguist-generated=true
 docs/src/generated/terminal-styles.json linguist-generated=true
+# Rendered from the USER_CONFIG and PROJECT_CONFIG blocks in src/cli/mod.rs by
+# `test_config_source_generates_example_toml` and
+# `test_project_config_source_generates_example_toml`.
+dev/*.example.toml linguist-generated=true
+# The command pages under docs/src/content/docs/ are generated from src/cli/mod.rs
+# too, but deliberately stay visible: they are the one rendered copy of the help
+# text a reviewer reads. The rest of that directory is hand-written.
+
 # Shell templates are embedded into the binary at compile time (askama); a
 # CRLF checkout would leak \r into the shell code Windows-built binaries emit.
 templates/* text eol=lf


### PR DESCRIPTION
A help-text edit in `src/cli/mod.rs` regenerates three mirrors of the same paragraphs, and `.gitattributes` collapsed only one of them. So a PR touching help text — most of the docs-survey PRs — showed the text three times over.

This marks the plugin skills tree and `dev/*.example.toml` generated as well, each with a comment naming what rewrites it. The command pages under `docs/src/content/docs/` deliberately stay visible: a reviewer should read the rendered help once, and the rest of that directory is hand-written primaries. Snapshots stay visible too — they are asserted content, not a mirror.

Verified with `git check-attr linguist-generated` over a generated file and a primary in each group, including the plugin mirror's copies of the skill-only pages (`troubleshooting.md`, `shell-integration.md`), which collapse there while their primaries under `skills/worktrunk/reference/` stay exempt.

<details>
<summary>Considered and left alone: <code>docs/public/schema/list-v2.json</code></summary>

It is generated by the same sync test, but `sync_json_schema`'s docstring says a schemars upgrade rewriting it "should be a reviewed diff" — collapsing it by default works against that.
</details>

> _This was written by Claude Code on behalf of max-sixty_
