### PR TITLE
Document copy-ignored's disk-space benefit

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Copy build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees, with copy-on-write
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones, so a new worktree starts warm without a second copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones on APFS, btrfs, and XFS, so ten worktrees share one copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — ten worktrees get `target/`, `node_modules/`, etc without building or copying them (on APFS, btrfs, and XFS)
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones, so a new worktree starts warm without a second copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree starts warm without a second copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree starts warm without a second copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree is immediately ready, and ten of them share one copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Copy build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees
+- **[Copy build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees, with copy-on-write
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree is immediately ready, and ten of them share one copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones on APFS, btrfs, and XFS, so ten worktrees share one copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/docs/src/content/docs/faq.md
+++ b/docs/src/content/docs/faq.md
@@ -55,6 +55,12 @@ These tools can be used together—run git-machete or git-town inside individual
 
 Git TUIs operate on a single repository. Worktrunk manages multiple worktrees, runs automation hooks, and aggregates status across branches. TUIs work inside each worktree directory.
 
+## How much disk do worktrees use?
+
+Worktrees share one `.git`. Each adds a checkout of the tracked files, plus whatever gitignored build output you copy in.
+
+On APFS, btrfs, and XFS (not ext4 or NTFS), [`wt step copy-ignored`](/step/#copy-on-write) reflinks that output, so a new worktree shares the primary worktree's disk blocks. A later build rewrites only what changed, and the rest stays shared. On one machine, 56 worktrees of a Rust repository with a 40GB `target/` came to 2.6TB by `du` and 0.7TB on disk.
+
 ## Does Worktrunk support stacked branches?
 
 Not natively — stacked-branch workflows are a large design space, so Worktrunk treats them as an extension rather than a built-in. [`worktrunk-sync`](https://github.com/pablospe/worktrunk-sync) is a community tool that auto-detects the branch dependency tree from git history and rebases each branch onto its parent in topological order. Install with `cargo install worktrunk-sync` and run as `wt sync` (via [custom subcommands](/extending/#custom-subcommands)).

--- a/docs/src/content/docs/step.md
+++ b/docs/src/content/docs/step.md
@@ -611,16 +611,18 @@ Without `.worktreeinclude`, the command is a no-op (it reports that nothing was 
 | Generated assets | Images, ML models, binaries too large for git |
 | Environment files | `.env` (if not generated per-worktree) |
 
-### Performance
+### Copy-on-write
 
-Reflink copies share disk blocks until modified — no data is actually copied. For a 14GB `target/` directory:
+Files are reflinked where the filesystem supports it: APFS (macOS), btrfs and XFS (Linux), ReFS (Windows). A reflinked copy shares the source's disk blocks until one side writes. For a 14GB `target/` directory:
 
-| Command | Time |
-|---------|------|
-| `cp -R` (full copy) | 2m |
-| `cp -Rc` / `wt step copy-ignored` | 20s |
+| Command | Time | Disk |
+|---------|------|------|
+| `cp -R` (full copy) | 2m | 14GB |
+| `cp -Rc` / `wt step copy-ignored` | 20s | ~0 |
 
-Uses per-file reflink (like `cp -Rc`) — copy time scales with file count.
+On ext4 and NTFS, which have no reflink, every file is copied in full.
+
+Reflinks are per file (like `cp -Rc`), so copy time scales with file count.
 
 Use the `post-start` hook so the copy runs in the background. Use `pre-start` instead if subsequent hooks or `--execute` command need the copied files immediately.
 
@@ -654,7 +656,6 @@ Virtual environments contain absolute paths and can't be copied. Use `uv sync` i
 The `.worktreeinclude` pattern is shared with [Claude Code on desktop](https://code.claude.com/docs/en/desktop), which copies matching files when creating worktrees. Differences:
 
 - worktrunk copies all gitignored files by default; Claude Code requires `.worktreeinclude`. Pass `--require-include` to match Claude Code (copy nothing without `.worktreeinclude`)
-- worktrunk uses copy-on-write for large directories like `target/` (see Performance above)
 - worktrunk runs as a configurable hook in the worktree lifecycle
 
 ### Command reference

--- a/docs/src/content/docs/worktrunk.md
+++ b/docs/src/content/docs/worktrunk.md
@@ -100,7 +100,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree is immediately ready, and ten of them share one copy on disk
+- **[Share build caches](/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones on APFS, btrfs, and XFS, so ten worktrees share one copy on disk
 - **[`wt list --full`](/list/#full-mode)** — [CI status](/list/#ci-status) and [AI-generated summaries](/list/#llm-summaries) per branch
 - **[PR checkout](/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/docs/src/content/docs/worktrunk.md
+++ b/docs/src/content/docs/worktrunk.md
@@ -100,7 +100,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Copy build caches](/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees
+- **[Copy build caches](/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees, with copy-on-write
 - **[`wt list --full`](/list/#full-mode)** — [CI status](/list/#ci-status) and [AI-generated summaries](/list/#llm-summaries) per branch
 - **[PR checkout](/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/docs/src/content/docs/worktrunk.md
+++ b/docs/src/content/docs/worktrunk.md
@@ -100,7 +100,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree starts warm without a second copy on disk
+- **[Share build caches](/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree is immediately ready, and ten of them share one copy on disk
 - **[`wt list --full`](/list/#full-mode)** — [CI status](/list/#ci-status) and [AI-generated summaries](/list/#llm-summaries) per branch
 - **[PR checkout](/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/docs/src/content/docs/worktrunk.md
+++ b/docs/src/content/docs/worktrunk.md
@@ -100,7 +100,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Copy build caches](/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees, with copy-on-write
+- **[Share build caches](/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones, so a new worktree starts warm without a second copy on disk
 - **[`wt list --full`](/list/#full-mode)** — [CI status](/list/#ci-status) and [AI-generated summaries](/list/#llm-summaries) per branch
 - **[PR checkout](/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/docs/src/content/docs/worktrunk.md
+++ b/docs/src/content/docs/worktrunk.md
@@ -100,7 +100,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones on APFS, btrfs, and XFS, so ten worktrees share one copy on disk
+- **[Share build caches](/step/#wt-step-copy-ignored)** — ten worktrees get `target/`, `node_modules/`, etc without building or copying them (on APFS, btrfs, and XFS)
 - **[`wt list --full`](/list/#full-mode)** — [CI status](/list/#ci-status) and [AI-generated summaries](/list/#llm-summaries) per branch
 - **[PR checkout](/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/docs/src/content/docs/worktrunk.md
+++ b/docs/src/content/docs/worktrunk.md
@@ -100,7 +100,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones, so a new worktree starts warm without a second copy on disk
+- **[Share build caches](/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree starts warm without a second copy on disk
 - **[`wt list --full`](/list/#full-mode)** — [CI status](/list/#ci-status) and [AI-generated summaries](/list/#llm-summaries) per branch
 - **[PR checkout](/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/plugins/worktrunk/skills/worktrunk/reference/README.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/README.md
@@ -90,7 +90,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Copy build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees, with copy-on-write
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones, so a new worktree starts warm without a second copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/plugins/worktrunk/skills/worktrunk/reference/README.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/README.md
@@ -90,7 +90,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones on APFS, btrfs, and XFS, so ten worktrees share one copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — ten worktrees get `target/`, `node_modules/`, etc without building or copying them (on APFS, btrfs, and XFS)
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/plugins/worktrunk/skills/worktrunk/reference/README.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/README.md
@@ -90,7 +90,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones, so a new worktree starts warm without a second copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree starts warm without a second copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/plugins/worktrunk/skills/worktrunk/reference/README.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/README.md
@@ -90,7 +90,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree starts warm without a second copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree is immediately ready, and ten of them share one copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/plugins/worktrunk/skills/worktrunk/reference/README.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/README.md
@@ -90,7 +90,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Copy build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees
+- **[Copy build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees, with copy-on-write
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/plugins/worktrunk/skills/worktrunk/reference/README.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/README.md
@@ -90,7 +90,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree is immediately ready, and ten of them share one copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones on APFS, btrfs, and XFS, so ten worktrees share one copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/plugins/worktrunk/skills/worktrunk/reference/faq.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/faq.md
@@ -51,6 +51,12 @@ These tools can be used together—run git-machete or git-town inside individual
 
 Git TUIs operate on a single repository. Worktrunk manages multiple worktrees, runs automation hooks, and aggregates status across branches. TUIs work inside each worktree directory.
 
+## How much disk do worktrees use?
+
+Worktrees share one `.git`. Each adds a checkout of the tracked files, plus whatever gitignored build output you copy in.
+
+On APFS, btrfs, and XFS (not ext4 or NTFS), [`wt step copy-ignored`](https://worktrunk.dev/step/#copy-on-write) reflinks that output, so a new worktree shares the primary worktree's disk blocks. A later build rewrites only what changed, and the rest stays shared. On one machine, 56 worktrees of a Rust repository with a 40GB `target/` came to 2.6TB by `du` and 0.7TB on disk.
+
 ## Does Worktrunk support stacked branches?
 
 Not natively — stacked-branch workflows are a large design space, so Worktrunk treats them as an extension rather than a built-in. [`worktrunk-sync`](https://github.com/pablospe/worktrunk-sync) is a community tool that auto-detects the branch dependency tree from git history and rebases each branch onto its parent in topological order. Install with `cargo install worktrunk-sync` and run as `wt sync` (via [custom subcommands](https://worktrunk.dev/extending/#custom-subcommands)).

--- a/plugins/worktrunk/skills/worktrunk/reference/step.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/step.md
@@ -599,16 +599,18 @@ Without `.worktreeinclude`, the command is a no-op (it reports that nothing was 
 | Generated assets | Images, ML models, binaries too large for git |
 | Environment files | `.env` (if not generated per-worktree) |
 
-### Performance
+### Copy-on-write
 
-Reflink copies share disk blocks until modified — no data is actually copied. For a 14GB `target/` directory:
+Files are reflinked where the filesystem supports it: APFS (macOS), btrfs and XFS (Linux), ReFS (Windows). A reflinked copy shares the source's disk blocks until one side writes. For a 14GB `target/` directory:
 
-| Command | Time |
-|---------|------|
-| `cp -R` (full copy) | 2m |
-| `cp -Rc` / `wt step copy-ignored` | 20s |
+| Command | Time | Disk |
+|---------|------|------|
+| `cp -R` (full copy) | 2m | 14GB |
+| `cp -Rc` / `wt step copy-ignored` | 20s | ~0 |
 
-Uses per-file reflink (like `cp -Rc`) — copy time scales with file count.
+On ext4 and NTFS, which have no reflink, every file is copied in full.
+
+Reflinks are per file (like `cp -Rc`), so copy time scales with file count.
 
 Use the `post-start` hook so the copy runs in the background. Use `pre-start` instead if subsequent hooks or `--execute` command need the copied files immediately.
 
@@ -642,7 +644,6 @@ Virtual environments contain absolute paths and can't be copied. Use `uv sync` i
 The `.worktreeinclude` pattern is shared with [Claude Code on desktop](https://code.claude.com/docs/en/desktop), which copies matching files when creating worktrees. Differences:
 
 - worktrunk copies all gitignored files by default; Claude Code requires `.worktreeinclude`. Pass `--require-include` to match Claude Code (copy nothing without `.worktreeinclude`)
-- worktrunk uses copy-on-write for large directories like `target/` (see Performance above)
 - worktrunk runs as a configurable hook in the worktree lifecycle
 
 ### Command reference

--- a/plugins/worktrunk/skills/worktrunk/reference/worktrunk.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/worktrunk.md
@@ -72,7 +72,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree starts warm without a second copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree is immediately ready, and ten of them share one copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/plugins/worktrunk/skills/worktrunk/reference/worktrunk.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/worktrunk.md
@@ -72,7 +72,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Copy build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees
+- **[Copy build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees, with copy-on-write
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/plugins/worktrunk/skills/worktrunk/reference/worktrunk.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/worktrunk.md
@@ -72,7 +72,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Copy build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees, with copy-on-write
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones, so a new worktree starts warm without a second copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/plugins/worktrunk/skills/worktrunk/reference/worktrunk.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/worktrunk.md
@@ -72,7 +72,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones, so a new worktree starts warm without a second copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree starts warm without a second copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/plugins/worktrunk/skills/worktrunk/reference/worktrunk.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/worktrunk.md
@@ -72,7 +72,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree is immediately ready, and ten of them share one copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones on APFS, btrfs, and XFS, so ten worktrees share one copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/plugins/worktrunk/skills/worktrunk/reference/worktrunk.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/worktrunk.md
@@ -72,7 +72,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones on APFS, btrfs, and XFS, so ten worktrees share one copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — ten worktrees get `target/`, `node_modules/`, etc without building or copying them (on APFS, btrfs, and XFS)
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -51,6 +51,12 @@ These tools can be used together—run git-machete or git-town inside individual
 
 Git TUIs operate on a single repository. Worktrunk manages multiple worktrees, runs automation hooks, and aggregates status across branches. TUIs work inside each worktree directory.
 
+## How much disk do worktrees use?
+
+Worktrees share one `.git`. Each adds a checkout of the tracked files, plus whatever gitignored build output you copy in.
+
+On APFS, btrfs, and XFS (not ext4 or NTFS), [`wt step copy-ignored`](https://worktrunk.dev/step/#copy-on-write) reflinks that output, so a new worktree shares the primary worktree's disk blocks. A later build rewrites only what changed, and the rest stays shared. On one machine, 56 worktrees of a Rust repository with a 40GB `target/` came to 2.6TB by `du` and 0.7TB on disk.
+
 ## Does Worktrunk support stacked branches?
 
 Not natively — stacked-branch workflows are a large design space, so Worktrunk treats them as an extension rather than a built-in. [`worktrunk-sync`](https://github.com/pablospe/worktrunk-sync) is a community tool that auto-detects the branch dependency tree from git history and rebases each branch onto its parent in topological order. Install with `cargo install worktrunk-sync` and run as `wt sync` (via [custom subcommands](https://worktrunk.dev/extending/#custom-subcommands)).

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -599,16 +599,18 @@ Without `.worktreeinclude`, the command is a no-op (it reports that nothing was 
 | Generated assets | Images, ML models, binaries too large for git |
 | Environment files | `.env` (if not generated per-worktree) |
 
-### Performance
+### Copy-on-write
 
-Reflink copies share disk blocks until modified — no data is actually copied. For a 14GB `target/` directory:
+Files are reflinked where the filesystem supports it: APFS (macOS), btrfs and XFS (Linux), ReFS (Windows). A reflinked copy shares the source's disk blocks until one side writes. For a 14GB `target/` directory:
 
-| Command | Time |
-|---------|------|
-| `cp -R` (full copy) | 2m |
-| `cp -Rc` / `wt step copy-ignored` | 20s |
+| Command | Time | Disk |
+|---------|------|------|
+| `cp -R` (full copy) | 2m | 14GB |
+| `cp -Rc` / `wt step copy-ignored` | 20s | ~0 |
 
-Uses per-file reflink (like `cp -Rc`) — copy time scales with file count.
+On ext4 and NTFS, which have no reflink, every file is copied in full.
+
+Reflinks are per file (like `cp -Rc`), so copy time scales with file count.
 
 Use the `post-start` hook so the copy runs in the background. Use `pre-start` instead if subsequent hooks or `--execute` command need the copied files immediately.
 
@@ -642,7 +644,6 @@ Virtual environments contain absolute paths and can't be copied. Use `uv sync` i
 The `.worktreeinclude` pattern is shared with [Claude Code on desktop](https://code.claude.com/docs/en/desktop), which copies matching files when creating worktrees. Differences:
 
 - worktrunk copies all gitignored files by default; Claude Code requires `.worktreeinclude`. Pass `--require-include` to match Claude Code (copy nothing without `.worktreeinclude`)
-- worktrunk uses copy-on-write for large directories like `target/` (see Performance above)
 - worktrunk runs as a configurable hook in the worktree lifecycle
 
 ### Command reference

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -72,7 +72,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree starts warm without a second copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree is immediately ready, and ten of them share one copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -72,7 +72,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Copy build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees
+- **[Copy build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees, with copy-on-write
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -72,7 +72,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Copy build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — skip cold starts by sharing `target/`, `node_modules/`, etc between worktrees, with copy-on-write
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones, so a new worktree starts warm without a second copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -72,7 +72,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones, so a new worktree starts warm without a second copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree starts warm without a second copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -72,7 +72,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones where the filesystem supports it, so a new worktree is immediately ready, and ten of them share one copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones on APFS, btrfs, and XFS, so ten worktrees share one copy on disk
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -72,7 +72,7 @@ git branch -d feat</code></pre></td>
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs
 - **[Merge workflow](https://worktrunk.dev/merge/)** — squash, rebase, merge, clean up in one command
 - **[Interactive picker](https://worktrunk.dev/switch/#interactive-picker)** — browse worktrees with live diff and log previews
-- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — `target/`, `node_modules/`, etc are copy-on-write clones on APFS, btrfs, and XFS, so ten worktrees share one copy on disk
+- **[Share build caches](https://worktrunk.dev/step/#wt-step-copy-ignored)** — ten worktrees get `target/`, `node_modules/`, etc without building or copying them (on APFS, btrfs, and XFS)
 - **[`wt list --full`](https://worktrunk.dev/list/#full-mode)** — [CI status](https://worktrunk.dev/list/#ci-status) and [AI-generated summaries](https://worktrunk.dev/list/#llm-summaries) per branch
 - **[PR checkout](https://worktrunk.dev/switch/#pull-requests-and-merge-requests)** — `wt switch pr:123` to jump straight to a PR's branch
 - **[Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree)** — `hash_port` template filter gives each worktree a unique port

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -379,16 +379,18 @@ Without `.worktreeinclude`, the command is a no-op (it reports that nothing was 
 | Generated assets | Images, ML models, binaries too large for git |
 | Environment files | `.env` (if not generated per-worktree) |
 
-## Performance
+## Copy-on-write
 
-Reflink copies share disk blocks until modified — no data is actually copied. For a 14GB `target/` directory:
+Files are reflinked where the filesystem supports it: APFS (macOS), btrfs and XFS (Linux), ReFS (Windows). A reflinked copy shares the source's disk blocks until one side writes. For a 14GB `target/` directory:
 
-| Command | Time |
-|---------|------|
-| `cp -R` (full copy) | 2m |
-| `cp -Rc` / `wt step copy-ignored` | 20s |
+| Command | Time | Disk |
+|---------|------|------|
+| `cp -R` (full copy) | 2m | 14GB |
+| `cp -Rc` / `wt step copy-ignored` | 20s | ~0 |
 
-Uses per-file reflink (like `cp -Rc`) — copy time scales with file count.
+On ext4 and NTFS, which have no reflink, every file is copied in full.
+
+Reflinks are per file (like `cp -Rc`), so copy time scales with file count.
 
 Use the `post-start` hook so the copy runs in the background. Use `pre-start` instead if subsequent hooks or `--execute` command need the copied files immediately.
 
@@ -422,7 +424,6 @@ Virtual environments contain absolute paths and can't be copied. Use `uv sync` i
 The `.worktreeinclude` pattern is shared with [Claude Code on desktop](https://code.claude.com/docs/en/desktop), which copies matching files when creating worktrees. Differences:
 
 - worktrunk copies all gitignored files by default; Claude Code requires `.worktreeinclude`. Pass `--require-include` to match Claude Code (copy nothing without `.worktreeinclude`)
-- worktrunk uses copy-on-write for large directories like `target/` (see Performance above)
 - worktrunk runs as a configurable hook in the worktree lifecycle
 "#)]
     CopyIgnored {

--- a/tests/snapshots/integration__integration_tests__help__help_step_copy_ignored.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_copy_ignored.snap
@@ -145,16 +145,18 @@ Without [2m.worktreeinclude[0m, the command is a no-op (it reports that nothin
  Generated assets  Images, ML models, binaries too large for git  
  Environment files [2m.env[0m (if not generated per-worktree)           
 
-[1m[32mPerformance[0m
+[1m[32mCopy-on-write[0m
 
-Reflink copies share disk blocks until modified — no data is actually copied. For a 14GB [2mtarget/[0m directory:
+Files are reflinked where the filesystem supports it: APFS (macOS), btrfs and XFS (Linux), ReFS (Windows). A reflinked copy shares the source's disk blocks until one side writes. For a 14GB [2mtarget/[0m directory:
 
-            Command            Time 
- ───────────────────────────── ──── 
- [2mcp -R[0m (full copy)             2m   
- [2mcp -Rc[0m / [2mwt step copy-ignored[0m 20s  
+            Command            Time Disk 
+ ───────────────────────────── ──── ──── 
+ [2mcp -R[0m (full copy)             2m   14GB 
+ [2mcp -Rc[0m / [2mwt step copy-ignored[0m 20s  ~0   
 
-Uses per-file reflink (like [2mcp -Rc[0m) — copy time scales with file count.
+On ext4 and NTFS, which have no reflink, every file is copied in full.
+
+Reflinks are per file (like [2mcp -Rc[0m), so copy time scales with file count.
 
 Use the [2mpost-start[0m hook so the copy runs in the background. Use [2mpre-start[0m instead if subsequent hooks or [2m--execute[0m command need the copied files immediately.
 
@@ -186,7 +188,6 @@ Virtual environments contain absolute paths and can't be copied. Use [2muv sync
 The [2m.worktreeinclude[0m pattern is shared with Claude Code on desktop, which copies matching files when creating worktrees. Differences:
 
 - worktrunk copies all gitignored files by default; Claude Code requires [2m.worktreeinclude[0m. Pass [2m--require-include[0m to match Claude Code (copy nothing without [2m.worktreeinclude[0m)
-- worktrunk uses copy-on-write for large directories like [2mtarget/[0m (see Performance above)
 - worktrunk runs as a configurable hook in the worktree lifecycle
 
 ----- stderr -----


### PR DESCRIPTION
`wt step copy-ignored` reflinks the files it copies, so a new worktree's `target/` shares disk blocks with the primary worktree's until something writes to them. That was documented only under a "Performance" heading, next to a table of times, where it read as an explanation of why the copy is fast rather than a benefit in its own right. Nothing quantified the disk saving, and the homepage bullet ("Copy build caches — skip cold starts…") sold the time and not the space.

The saving is large and it survives real use: cargo writes new files for changed crates rather than rewriting dependency rlibs, so the bulk of `target/` stays shared as a worktree is built in. Measured across 56 worktrees of this repo on one machine, `du` reports 2.59 TB where the disk holds 0.71 TB.

Changes:

- Rename the `copy-ignored` "Performance" section to "Copy-on-write", add a Disk column to the existing table, and name the filesystems that support reflink along with what happens on ext4 and NTFS. Nothing linked to the old `#performance` anchor.
- Add an FAQ question, "How much disk do worktrees use?", for the fleet-level number — what someone weighing a many-worktree workflow actually wants to know, and a question the FAQ didn't answer.
- Rewrite the homepage bullet as "Share build caches" — "Copy" named the thing the feature avoids doing — and state both benefits: `target/`, `node_modules/`, etc reach ten worktrees without being built or copied.
- Drop the copy-on-write bullet from the Claude Code comparison. Claude Code ships compiled with Bun, whose `fs.copyFile` uses `clonefile()` on macOS, so it isn't a difference there: on a 2 GB file, Bun's `copyFileSync` consumed 6 MiB against Node's 2111 MiB. The remaining bullets carry the real differences.

The filesystem scope is stated wherever a claim is made, since reflink needs APFS, btrfs, XFS, or ReFS; ext4 and NTFS fall back to a full copy.

Follow-up, not in this PR: `reflink_or_copy` returns `None` on reflink and `Some(bytes)` on fallback, and `src/copy.rs:125` matches `Ok(_)` and discards it. So a user on ext4 gets a full copy, is told `Copied N files · 29.5 GB`, and has no way to learn which they got. The docs now state the caveat per filesystem; the command could state it per machine.

> _This was written by Claude Code on behalf of max-sixty_

