### PR TITLE
Cancel superseded PR release checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,10 @@ on:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:


### PR DESCRIPTION
Cancel superseded cargo-dist plan checks when a pull request receives a newer commit. Tag-triggered releases use a unique concurrency group and keep cancellation disabled, so actual releases cannot cancel one another.

> _This was written by Codex on behalf of max-sixty_
