### PR TITLE
fix(config): let uninstall succeed when the marketplace is already gone

### DIFF
--- a/src/commands/config/codex.rs
+++ b/src/commands/config/codex.rs
@@ -105,7 +105,10 @@ fn require_codex_cli() -> Result<()> {
 /// Codex's config root.
 ///
 /// Honors `CODEX_HOME`, which relocates the whole tree away from `~/.codex`,
-/// the same way `claude_config_dir` honors `CLAUDE_CONFIG_DIR`.
+/// the same way `claude_config_dir` honors `CLAUDE_CONFIG_DIR`. They diverge
+/// on one point deliberately: a leading `~/` is taken literally here rather
+/// than expanded against the home directory, because a shell expands it before
+/// the variable is set and nothing sets `CODEX_HOME` from a non-shell context.
 fn codex_config_dir() -> Option<PathBuf> {
     match std::env::var("CODEX_HOME") {
         Ok(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),

--- a/src/commands/config/codex.rs
+++ b/src/commands/config/codex.rs
@@ -105,19 +105,12 @@ fn require_codex_cli() -> Result<()> {
 /// Codex's config root.
 ///
 /// Honors `CODEX_HOME`, which relocates the whole tree away from `~/.codex`,
-/// the same way `claude_config_dir` honors `CLAUDE_CONFIG_DIR`. A leading
-/// `~/` is expanded against the home directory, since a variable set outside
-/// a shell reaches us unexpanded.
+/// the same way `claude_config_dir` honors `CLAUDE_CONFIG_DIR`.
 fn codex_config_dir() -> Option<PathBuf> {
-    if let Ok(dir) = std::env::var("CODEX_HOME")
-        && !dir.is_empty()
-    {
-        if let Some(rest) = dir.strip_prefix("~/") {
-            return worktrunk::path::home_dir().map(|home| home.join(rest));
-        }
-        return Some(PathBuf::from(dir));
+    match std::env::var("CODEX_HOME") {
+        Ok(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
+        _ => worktrunk::path::home_dir().map(|home| home.join(".codex")),
     }
-    worktrunk::path::home_dir().map(|home| home.join(".codex"))
 }
 
 /// Whether the worktrunk marketplace is configured in Codex.
@@ -127,20 +120,16 @@ fn codex_config_dir() -> Option<PathBuf> {
 /// genuinely failed. Codex records each one as a `[marketplaces.<name>]`
 /// table in `config.toml`.
 pub(super) fn is_marketplace_configured() -> bool {
-    let Some(config_dir) = codex_config_dir() else {
+    let Some(content) =
+        codex_config_dir().and_then(|dir| std::fs::read_to_string(dir.join("config.toml")).ok())
+    else {
         return false;
     };
 
-    let Ok(content) = std::fs::read_to_string(config_dir.join("config.toml")) else {
-        return false;
-    };
-
-    let Ok(config) = content.parse::<toml::Table>() else {
-        return false;
-    };
-
-    config
-        .get("marketplaces")
-        .and_then(|m| m.get(MARKETPLACE_NAME))
-        .is_some()
+    content.parse::<toml::Table>().is_ok_and(|config| {
+        config
+            .get("marketplaces")
+            .and_then(|m| m.get(MARKETPLACE_NAME))
+            .is_some()
+    })
 }

--- a/src/commands/config/codex.rs
+++ b/src/commands/config/codex.rs
@@ -124,20 +124,28 @@ fn codex_config_dir() -> Option<PathBuf> {
 /// genuinely failed. Codex records each one as a `[marketplaces.<name>]`
 /// table in `config.toml`.
 ///
-/// `None` is the same "cannot tell" the Claude reader returns, and for the
-/// same reason: a `config.toml` that exists and will not parse must not be
-/// read as the marketplace being gone.
+/// `None` is the same "cannot tell" the Claude reader returns: a `config.toml`
+/// that will not read or parse, or whose `marketplaces` is not a table, cannot
+/// say worktrunk's entry is gone.
+///
+/// It claims less than the Claude reader does, because less is available here.
+/// A fresh `config.toml` legitimately has no `marketplaces` key at all, so a
+/// key that was renamed or relocated is indistinguishable from a user who has
+/// configured no marketplaces, and reads as a confident absence.
 pub(super) fn is_marketplace_configured() -> Option<bool> {
     let path = codex_config_dir()?.join("config.toml");
-    if !path.exists() {
+    // `try_exists` so a directory we lack permission to stat is unknown rather
+    // than the `false` that `exists` reports for it.
+    if !path.try_exists().ok()? {
         return Some(false);
     }
 
     let content = std::fs::read_to_string(&path).ok()?;
-    content.parse::<toml::Table>().ok().map(|config| {
-        config
-            .get("marketplaces")
-            .and_then(|m| m.get(MARKETPLACE_NAME))
-            .is_some()
-    })
+    let config = content.parse::<toml::Table>().ok()?;
+    match config.get("marketplaces") {
+        None => Some(false),
+        Some(marketplaces) => marketplaces
+            .as_table()
+            .map(|table| table.contains_key(MARKETPLACE_NAME)),
+    }
 }

--- a/src/commands/config/codex.rs
+++ b/src/commands/config/codex.rs
@@ -1,5 +1,7 @@
 //! Codex plugin and marketplace management.
 
+use std::path::PathBuf;
+
 use anyhow::{Result, bail};
 use color_print::cformat;
 use worktrunk::styling::{eprintln, hint_message, progress_message, success_message};
@@ -81,9 +83,10 @@ pub fn handle_codex_uninstall(yes: bool) -> Result<()> {
         "{}",
         progress_message("Removing Codex plugin marketplace...")
     );
-    super::run_plugin_cli(
+    super::run_plugin_removal(
         "codex",
         &["plugin", "marketplace", "remove", MARKETPLACE_NAME],
+        is_marketplace_configured,
     )?;
 
     eprintln!("{}", success_message("Codex plugin & marketplace removed"));
@@ -97,4 +100,47 @@ fn require_codex_cli() -> Result<()> {
     }
 
     bail!("codex CLI not found. Install Codex first: https://developers.openai.com/codex/cli/");
+}
+
+/// Codex's config root.
+///
+/// Honors `CODEX_HOME`, which relocates the whole tree away from `~/.codex`,
+/// the same way `claude_config_dir` honors `CLAUDE_CONFIG_DIR`. A leading
+/// `~/` is expanded against the home directory, since a variable set outside
+/// a shell reaches us unexpanded.
+fn codex_config_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("CODEX_HOME")
+        && !dir.is_empty()
+    {
+        if let Some(rest) = dir.strip_prefix("~/") {
+            return worktrunk::path::home_dir().map(|home| home.join(rest));
+        }
+        return Some(PathBuf::from(dir));
+    }
+    worktrunk::path::home_dir().map(|home| home.join(".codex"))
+}
+
+/// Whether the worktrunk marketplace is configured in Codex.
+///
+/// `codex plugin marketplace remove` exits non-zero when the marketplace is
+/// not configured, so uninstall needs to tell that from a removal that
+/// genuinely failed. Codex records each one as a `[marketplaces.<name>]`
+/// table in `config.toml`.
+pub(super) fn is_marketplace_configured() -> bool {
+    let Some(config_dir) = codex_config_dir() else {
+        return false;
+    };
+
+    let Ok(content) = std::fs::read_to_string(config_dir.join("config.toml")) else {
+        return false;
+    };
+
+    let Ok(config) = content.parse::<toml::Table>() else {
+        return false;
+    };
+
+    config
+        .get("marketplaces")
+        .and_then(|m| m.get(MARKETPLACE_NAME))
+        .is_some()
 }

--- a/src/commands/config/codex.rs
+++ b/src/commands/config/codex.rs
@@ -116,20 +116,25 @@ fn codex_config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Whether the worktrunk marketplace is configured in Codex.
+/// Whether the worktrunk marketplace is configured in Codex, or `None` where
+/// the config cannot answer.
 ///
 /// `codex plugin marketplace remove` exits non-zero when the marketplace is
 /// not configured, so uninstall needs to tell that from a removal that
 /// genuinely failed. Codex records each one as a `[marketplaces.<name>]`
 /// table in `config.toml`.
-pub(super) fn is_marketplace_configured() -> bool {
-    let Some(content) =
-        codex_config_dir().and_then(|dir| std::fs::read_to_string(dir.join("config.toml")).ok())
-    else {
-        return false;
-    };
+///
+/// `None` is the same "cannot tell" the Claude reader returns, and for the
+/// same reason: a `config.toml` that exists and will not parse must not be
+/// read as the marketplace being gone.
+pub(super) fn is_marketplace_configured() -> Option<bool> {
+    let path = codex_config_dir()?.join("config.toml");
+    if !path.exists() {
+        return Some(false);
+    }
 
-    content.parse::<toml::Table>().is_ok_and(|config| {
+    let content = std::fs::read_to_string(&path).ok()?;
+    content.parse::<toml::Table>().ok().map(|config| {
         config
             .get("marketplaces")
             .and_then(|m| m.get(MARKETPLACE_NAME))

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -143,6 +143,29 @@ fn run_plugin_cli(program: &str, args: &[&str]) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Run a removal whose goal is that the target is gone.
+///
+/// Both harnesses' `plugin marketplace remove` exits non-zero when the
+/// marketplace is not configured, which is the state the removal is trying to
+/// reach, so running `uninstall` twice would otherwise fail with nothing left
+/// to do. Asking `still_configured` after the attempt tells that apart from a
+/// removal that genuinely failed, which still surfaces the harness's own
+/// stderr in the gutter.
+///
+/// The command runs either way, so the `?` preview lists what the uninstall
+/// actually invokes.
+fn run_plugin_removal(
+    program: &str,
+    args: &[&str],
+    still_configured: impl Fn() -> bool,
+) -> anyhow::Result<()> {
+    match run_plugin_cli(program, args) {
+        Ok(()) => Ok(()),
+        Err(err) if still_configured() => Err(err),
+        Err(_) => Ok(()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use insta::assert_snapshot;

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -152,12 +152,12 @@ fn run_plugin_cli(program: &str, args: &[&str]) -> anyhow::Result<()> {
 /// removal that genuinely failed, which still surfaces the harness's own
 /// stderr in the gutter.
 ///
-/// Only a confident `Some(false)` drops the error. `None` — the config missing
-/// a home directory, or existing and refusing to read or parse — keeps it,
-/// because a reader that cannot see the marketplace has not established that
-/// the removal worked. Reporting success there would fail open on exactly the
-/// silent case: a config whose shape changed under us would swallow every
-/// genuine failure and print `Plugin & marketplace removed`.
+/// Only a confident `Some(false)` drops the error. `None` — no home directory,
+/// or a config that will not read, parse, or match the shape the reader knows
+/// — keeps it, because a reader that cannot see the marketplace has not
+/// established that the removal worked. Reporting success there would fail open
+/// on exactly the silent case: a config whose shape changed under us would
+/// swallow every genuine failure and print `Plugin & marketplace removed`.
 ///
 /// The command runs either way, so the `?` preview lists what the uninstall
 /// actually invokes.

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -152,17 +152,26 @@ fn run_plugin_cli(program: &str, args: &[&str]) -> anyhow::Result<()> {
 /// removal that genuinely failed, which still surfaces the harness's own
 /// stderr in the gutter.
 ///
+/// Only a confident `Some(false)` drops the error. `None` — the config missing
+/// a home directory, or existing and refusing to read or parse — keeps it,
+/// because a reader that cannot see the marketplace has not established that
+/// the removal worked. Reporting success there would fail open on exactly the
+/// silent case: a config whose shape changed under us would swallow every
+/// genuine failure and print `Plugin & marketplace removed`.
+///
 /// The command runs either way, so the `?` preview lists what the uninstall
 /// actually invokes.
 fn run_plugin_removal(
     program: &str,
     args: &[&str],
-    still_configured: impl Fn() -> bool,
+    still_configured: impl Fn() -> Option<bool>,
 ) -> anyhow::Result<()> {
     match run_plugin_cli(program, args) {
         Ok(()) => Ok(()),
-        Err(err) if still_configured() => Err(err),
-        Err(_) => Ok(()),
+        Err(err) => match still_configured() {
+            Some(false) => Ok(()),
+            _ => Err(err),
+        },
     }
 }
 

--- a/src/commands/config/plugins.rs
+++ b/src/commands/config/plugins.rs
@@ -7,7 +7,8 @@ use color_print::cformat;
 use worktrunk::styling::{eprintln, info_message, progress_message, success_message};
 
 use super::show::{
-    claude_config_dir, is_claude_available, is_plugin_installed, is_statusline_configured,
+    claude_config_dir, is_claude_available, is_marketplace_configured, is_plugin_installed,
+    is_statusline_configured,
 };
 use crate::output::prompt::{PromptResponse, prompt_yes_no_preview};
 
@@ -76,7 +77,11 @@ pub fn handle_claude_uninstall(yes: bool) -> anyhow::Result<()> {
         "{}",
         progress_message("Removing Claude Code plugin marketplace...")
     );
-    super::run_plugin_cli("claude", &["plugin", "marketplace", "remove", "worktrunk"])?;
+    super::run_plugin_removal(
+        "claude",
+        &["plugin", "marketplace", "remove", "worktrunk"],
+        is_marketplace_configured,
+    )?;
 
     eprintln!("{}", success_message("Plugin & marketplace removed"));
 

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -239,22 +239,32 @@ pub(super) fn is_plugin_installed() -> bool {
         .is_some()
 }
 
-/// Check if the worktrunk marketplace is configured in Claude Code
+/// Whether the worktrunk marketplace is configured in Claude Code, or `None`
+/// where the config cannot answer
 ///
 /// Read from the same config tree as `is_plugin_installed`, and asked for the
 /// same reason: `claude plugin marketplace remove` exits non-zero when the
 /// marketplace is not there, so uninstall needs to tell that from a removal
 /// that genuinely failed. `known_marketplaces.json` is keyed by marketplace
 /// name.
-pub(super) fn is_marketplace_configured() -> bool {
-    let Some(content) = claude_config_dir()
-        .and_then(|dir| std::fs::read_to_string(dir.join("plugins/known_marketplaces.json")).ok())
-    else {
-        return false;
-    };
+///
+/// The three-way answer is what keeps that safe. A file Claude Code has never
+/// written records no marketplaces, so its absence is a confident no. A file
+/// that exists and cannot be read or parsed leaves the question open, and
+/// `run_plugin_removal` keeps the harness's error rather than reporting a
+/// removal it cannot confirm — the case that matters if this file's shape ever
+/// changes, the way the `installed_plugins.json` beside it wraps its map in a
+/// `version` key.
+pub(super) fn is_marketplace_configured() -> Option<bool> {
+    let path = claude_config_dir()?.join("plugins/known_marketplaces.json");
+    if !path.exists() {
+        return Some(false);
+    }
 
+    let content = std::fs::read_to_string(&path).ok()?;
     serde_json::from_str::<serde_json::Value>(&content)
-        .is_ok_and(|json| json.get("worktrunk").is_some())
+        .ok()
+        .map(|json| json.get("worktrunk").is_some())
 }
 
 /// Whether Claude Code's statusline runs worktrunk's.

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -247,20 +247,14 @@ pub(super) fn is_plugin_installed() -> bool {
 /// that genuinely failed. `known_marketplaces.json` is keyed by marketplace
 /// name.
 pub(super) fn is_marketplace_configured() -> bool {
-    let Some(config_dir) = claude_config_dir() else {
+    let Some(content) = claude_config_dir()
+        .and_then(|dir| std::fs::read_to_string(dir.join("plugins/known_marketplaces.json")).ok())
+    else {
         return false;
     };
 
-    let marketplaces_file = config_dir.join("plugins/known_marketplaces.json");
-    let Ok(content) = std::fs::read_to_string(&marketplaces_file) else {
-        return false;
-    };
-
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
-        return false;
-    };
-
-    json.get("worktrunk").is_some()
+    serde_json::from_str::<serde_json::Value>(&content)
+        .is_ok_and(|json| json.get("worktrunk").is_some())
 }
 
 /// Whether Claude Code's statusline runs worktrunk's.

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -250,21 +250,30 @@ pub(super) fn is_plugin_installed() -> bool {
 ///
 /// The three-way answer is what keeps that safe. A file Claude Code has never
 /// written records no marketplaces, so its absence is a confident no. A file
-/// that exists and cannot be read or parsed leaves the question open, and
-/// `run_plugin_removal` keeps the harness's error rather than reporting a
-/// removal it cannot confirm — the case that matters if this file's shape ever
-/// changes, the way the `installed_plugins.json` beside it wraps its map in a
-/// `version` key.
+/// that exists and cannot be read, parsed, or recognized leaves the question
+/// open, and `run_plugin_removal` keeps the harness's error rather than
+/// reporting a removal it cannot confirm.
+///
+/// Recognizing the shape is the part that earns its keep. A key lookup alone
+/// answers "absent" for any JSON that simply lacks it, so a file reshaped the
+/// way the `installed_plugins.json` beside it wraps its map in a `version` key
+/// would parse, miss, and report a confident no — every genuine failure
+/// silently reported as success. Requiring every value to be a marketplace
+/// object turns that reshape into `None` instead.
 pub(super) fn is_marketplace_configured() -> Option<bool> {
     let path = claude_config_dir()?.join("plugins/known_marketplaces.json");
-    if !path.exists() {
+    // `try_exists` so a directory we lack permission to stat is unknown rather
+    // than the `false` that `exists` reports for it.
+    if !path.try_exists().ok()? {
         return Some(false);
     }
 
     let content = std::fs::read_to_string(&path).ok()?;
-    serde_json::from_str::<serde_json::Value>(&content)
-        .ok()
-        .map(|json| json.get("worktrunk").is_some())
+    let json = serde_json::from_str::<serde_json::Value>(&content).ok()?;
+    let map = json.as_object()?;
+    map.values()
+        .all(serde_json::Value::is_object)
+        .then(|| map.contains_key("worktrunk"))
 }
 
 /// Whether Claude Code's statusline runs worktrunk's.

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -239,6 +239,30 @@ pub(super) fn is_plugin_installed() -> bool {
         .is_some()
 }
 
+/// Check if the worktrunk marketplace is configured in Claude Code
+///
+/// Read from the same config tree as `is_plugin_installed`, and asked for the
+/// same reason: `claude plugin marketplace remove` exits non-zero when the
+/// marketplace is not there, so uninstall needs to tell that from a removal
+/// that genuinely failed. `known_marketplaces.json` is keyed by marketplace
+/// name.
+pub(super) fn is_marketplace_configured() -> bool {
+    let Some(config_dir) = claude_config_dir() else {
+        return false;
+    };
+
+    let marketplaces_file = config_dir.join("plugins/known_marketplaces.json");
+    let Ok(content) = std::fs::read_to_string(&marketplaces_file) else {
+        return false;
+    };
+
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+
+    json.get("worktrunk").is_some()
+}
+
 /// Whether Claude Code's statusline runs worktrunk's.
 ///
 /// The question is which subcommand the configured command invokes, so it's

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1192,6 +1192,11 @@ pub fn set_temp_home_env(cmd: &mut Command, home: &Path) {
         "PI_PROFILE",
         "PI_CONFIG_DIR",
         "PI_CODING_AGENT_DIR",
+        // Codex resolves its config root from CODEX_HOME, falling back to
+        // `$HOME/.codex` — which the temp home already pins. Dropping an
+        // ambient value is all hermeticity needs, and unlike setting one it
+        // keeps the variable out of every snapshot's env block.
+        "CODEX_HOME",
     ] {
         cmd.env_remove(var);
     }
@@ -2237,6 +2242,34 @@ impl TestRepo {
         .unwrap();
     }
 
+    /// Record the worktrunk marketplace as configured in Claude Code
+    ///
+    /// `known_marketplaces.json` is keyed by marketplace name, which is what
+    /// `is_marketplace_configured` reads.
+    pub fn setup_claude_marketplace_configured(temp_home: &std::path::Path) {
+        let plugins_dir = temp_home.join(".claude/plugins");
+        std::fs::create_dir_all(&plugins_dir).unwrap();
+        std::fs::write(
+            plugins_dir.join("known_marketplaces.json"),
+            r#"{"worktrunk":{"source":{"source":"github","repo":"max-sixty/worktrunk"}}}"#,
+        )
+        .unwrap();
+    }
+
+    /// Record the worktrunk marketplace as configured in Codex
+    ///
+    /// Codex keeps each one as a `[marketplaces.<name>]` table in
+    /// `config.toml`.
+    pub fn setup_codex_marketplace_configured(temp_home: &std::path::Path) {
+        let codex_dir = temp_home.join(".codex");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        std::fs::write(
+            codex_dir.join("config.toml"),
+            "[marketplaces.worktrunk]\nsource_type = \"git\"\nsource = \"https://github.com/max-sixty/worktrunk.git\"\n",
+        )
+        .unwrap();
+    }
+
     /// Setup the statusline as configured in Claude Code settings
     ///
     /// Creates the settings.json file with the wt statusline command.
@@ -2353,6 +2386,56 @@ impl TestRepo {
         MockConfig::new("codex")
             .command("plugin marketplace add", MockResponse::exit(0))
             .command("plugin marketplace remove", MockResponse::exit(0))
+            .command("plugin add", MockResponse::exit(0))
+            .command("plugin remove", MockResponse::exit(0))
+            .write(mock_bin);
+
+        self.codex_installed = true;
+    }
+
+    /// Setup mock `claude` CLI whose only failing command is the marketplace
+    /// removal
+    ///
+    /// Uninstall reads the config to tell "the marketplace was already gone"
+    /// from a removal that genuinely failed, so the two cases need a mock that
+    /// fails the removal and leaves every other step alone. Must call
+    /// `setup_mock_ci_tools_unauthenticated()` first.
+    pub fn setup_mock_claude_with_marketplace_remove_failing(&mut self) {
+        let mock_bin = self
+            .mock_bin_path
+            .as_ref()
+            .expect("call setup_mock_ci_tools_unauthenticated() first");
+
+        MockConfig::new("claude")
+            .command("plugin marketplace add", MockResponse::exit(0))
+            .command(
+                "plugin marketplace remove",
+                MockResponse::exit(1).with_stderr("error: marketplace remove failed\n"),
+            )
+            .command("plugin install", MockResponse::exit(0))
+            .command("plugin uninstall", MockResponse::exit(0))
+            .write(mock_bin);
+
+        self.claude_installed = true;
+    }
+
+    /// Setup mock `codex` CLI whose only failing command is the marketplace
+    /// removal
+    ///
+    /// The Codex counterpart of
+    /// `setup_mock_claude_with_marketplace_remove_failing`.
+    pub fn setup_mock_codex_with_marketplace_remove_failing(&mut self) {
+        let mock_bin = self
+            .mock_bin_path
+            .as_ref()
+            .expect("call setup_mock_ci_tools_unauthenticated() first");
+
+        MockConfig::new("codex")
+            .command("plugin marketplace add", MockResponse::exit(0))
+            .command(
+                "plugin marketplace remove",
+                MockResponse::exit(1).with_stderr("error: marketplace remove failed\n"),
+            )
             .command("plugin add", MockResponse::exit(0))
             .command("plugin remove", MockResponse::exit(0))
             .write(mock_bin);

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -2259,10 +2259,10 @@ impl TestRepo {
     /// Record the worktrunk marketplace as configured in Codex
     ///
     /// Codex keeps each one as a `[marketplaces.<name>]` table in
-    /// `config.toml`.
-    pub fn setup_codex_marketplace_configured(temp_home: &std::path::Path) {
-        let codex_dir = temp_home.join(".codex");
-        std::fs::create_dir_all(&codex_dir).unwrap();
+    /// `config.toml`. Takes the config root rather than the home directory,
+    /// since `CODEX_HOME` can move it off `~/.codex`.
+    pub fn setup_codex_marketplace_configured(codex_dir: &std::path::Path) {
+        std::fs::create_dir_all(codex_dir).unwrap();
         std::fs::write(
             codex_dir.join("config.toml"),
             "[marketplaces.worktrunk]\nsource_type = \"git\"\nsource = \"https://github.com/max-sixty/worktrunk.git\"\n",

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -2242,33 +2242,49 @@ impl TestRepo {
         .unwrap();
     }
 
-    /// Record the worktrunk marketplace as configured in Claude Code
+    /// Write Claude Code's marketplace record verbatim
     ///
     /// `known_marketplaces.json` is keyed by marketplace name, which is what
-    /// `is_marketplace_configured` reads.
-    pub fn setup_claude_marketplace_configured(temp_home: &std::path::Path) {
+    /// `is_marketplace_configured` reads. The body is the caller's, since the
+    /// three states that reader distinguishes — worktrunk present, a different
+    /// marketplace present, and a file that will not parse — differ only in
+    /// what this file holds.
+    pub fn setup_claude_marketplaces(temp_home: &std::path::Path, body: &str) {
         let plugins_dir = temp_home.join(".claude/plugins");
         std::fs::create_dir_all(&plugins_dir).unwrap();
-        std::fs::write(
-            plugins_dir.join("known_marketplaces.json"),
-            r#"{"worktrunk":{"source":{"source":"github","repo":"max-sixty/worktrunk"}}}"#,
-        )
-        .unwrap();
+        std::fs::write(plugins_dir.join("known_marketplaces.json"), body).unwrap();
     }
 
-    /// Record the worktrunk marketplace as configured in Codex
+    /// `known_marketplaces.json` holding the worktrunk marketplace
+    pub const CLAUDE_MARKETPLACES_WITH_WORKTRUNK: &'static str =
+        r#"{"worktrunk":{"source":{"source":"github","repo":"max-sixty/worktrunk"}}}"#;
+
+    /// `known_marketplaces.json` holding some other marketplace
     ///
-    /// Codex keeps each one as a `[marketplaces.<name>]` table in
-    /// `config.toml`. Takes the config root rather than the home directory,
-    /// since `CODEX_HOME` can move it off `~/.codex`.
-    pub fn setup_codex_marketplace_configured(codex_dir: &std::path::Path) {
+    /// The state a second `uninstall` lands in: the file exists because the
+    /// user has other marketplaces, and worktrunk's entry is simply gone.
+    pub const CLAUDE_MARKETPLACES_WITHOUT_WORKTRUNK: &'static str =
+        r#"{"other":{"source":{"source":"github","repo":"someone/other"}}}"#;
+
+    /// Write Codex's `config.toml` verbatim
+    ///
+    /// Codex keeps each marketplace as a `[marketplaces.<name>]` table there.
+    /// Takes the config root rather than the home directory, since
+    /// `CODEX_HOME` can move it off `~/.codex`.
+    pub fn setup_codex_config(codex_dir: &std::path::Path, body: &str) {
         std::fs::create_dir_all(codex_dir).unwrap();
-        std::fs::write(
-            codex_dir.join("config.toml"),
-            "[marketplaces.worktrunk]\nsource_type = \"git\"\nsource = \"https://github.com/max-sixty/worktrunk.git\"\n",
-        )
-        .unwrap();
+        std::fs::write(codex_dir.join("config.toml"), body).unwrap();
     }
+
+    /// `config.toml` holding the worktrunk marketplace
+    pub const CODEX_CONFIG_WITH_WORKTRUNK: &'static str = "[marketplaces.worktrunk]\nsource_type = \"git\"\nsource = \"https://github.com/max-sixty/worktrunk.git\"\n";
+
+    /// `config.toml` a Codex user has after the marketplace is removed
+    ///
+    /// Codex keeps its model and other settings in this file, so it outlives
+    /// the marketplace table — which is why a second `uninstall` reads a
+    /// present config with no worktrunk entry rather than no config at all.
+    pub const CODEX_CONFIG_WITHOUT_WORKTRUNK: &'static str = "model = \"gpt-5.5\"\n\n[marketplaces.other]\nsource_type = \"git\"\nsource = \"https://github.com/someone/other.git\"\n";
 
     /// Setup the statusline as configured in Claude Code settings
     ///

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -4396,7 +4396,7 @@ fn test_plugins_codex_uninstall_surfaces_marketplace_remove_failure(
 ) {
     repo.setup_mock_ci_tools_unauthenticated();
     repo.setup_mock_codex_with_marketplace_remove_failing();
-    TestRepo::setup_codex_marketplace_configured(temp_home.path());
+    TestRepo::setup_codex_marketplace_configured(&temp_home.path().join(".codex"));
 
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
@@ -4407,6 +4407,35 @@ fn test_plugins_codex_uninstall_surfaces_marketplace_remove_failure(
 
         assert_cmd_snapshot!(cmd);
     });
+}
+
+/// `CODEX_HOME` moves the config Codex reads, so the marketplace lookup has to
+/// follow it rather than the home directory. Asserted directly rather than by
+/// snapshot, which would put the variable's temp path in the snapshot's env
+/// block and trip the host-path guard.
+#[rstest]
+fn test_plugins_codex_uninstall_reads_codex_home(mut repo: TestRepo, temp_home: TempDir) {
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_codex_with_marketplace_remove_failing();
+
+    // The marketplace is recorded under CODEX_HOME and nowhere else, so a
+    // lookup that ignored the variable would find no config and read the
+    // failed removal as "already gone".
+    let codex_home = TempDir::new().unwrap();
+    TestRepo::setup_codex_marketplace_configured(codex_home.path());
+
+    let mut cmd = repo.wt_command();
+    cmd.args(["config", "plugins", "codex", "uninstall", "--yes"])
+        .current_dir(repo.root_path());
+    set_temp_home_env(&mut cmd, temp_home.path());
+    cmd.env("CODEX_HOME", codex_home.path());
+
+    let output = cmd.output().unwrap();
+    assert!(
+        !output.status.success(),
+        "a marketplace still configured under CODEX_HOME must surface the removal failure: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -4419,6 +4419,60 @@ fn test_plugins_claude_uninstall_surfaces_failure_when_config_unreadable(
     });
 }
 
+/// A reshaped `known_marketplaces.json` parses cleanly and simply lacks the
+/// key, so a lookup that only asked for the key would call the marketplace
+/// gone and swallow the removal's failure — silently, for as long as the shape
+/// held. Requiring every value to be a marketplace object makes it unknown.
+#[rstest]
+fn test_plugins_claude_uninstall_surfaces_failure_when_config_reshaped(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+) {
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_claude_with_marketplace_remove_failing();
+    TestRepo::setup_plugin_installed(temp_home.path());
+    // The shape `installed_plugins.json` already uses, applied to this file.
+    TestRepo::setup_claude_marketplaces(
+        temp_home.path(),
+        r#"{"version":2,"marketplaces":{"worktrunk":{"source":"github"}}}"#,
+    );
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "plugins", "claude", "uninstall", "--yes"])
+            .current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+/// The Codex counterpart, for the one shape it can rule out: `marketplaces`
+/// present but not a table cannot say worktrunk's entry is absent.
+#[rstest]
+fn test_plugins_codex_uninstall_surfaces_failure_when_config_reshaped(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+) {
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_codex_with_marketplace_remove_failing();
+    TestRepo::setup_codex_config(
+        &temp_home.path().join(".codex"),
+        "model = \"gpt-5.5\"\nmarketplaces = 3\n",
+    );
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "plugins", "codex", "uninstall", "--yes"])
+            .current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
 /// The Codex counterpart: a second `uninstall` succeeds.
 #[rstest]
 fn test_plugins_codex_uninstall_tolerates_absent_marketplace(

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -4341,6 +4341,74 @@ fn test_plugins_codex_uninstall_plugin_remove_fails(mut repo: TestRepo, temp_hom
     });
 }
 
+/// The marketplace removal's goal is that the marketplace is gone, so the
+/// harness reporting it was never configured is that goal already met. Running
+/// `uninstall` a second time hits exactly this, and used to fail with nothing
+/// left to do.
+#[rstest]
+fn test_plugins_claude_uninstall_tolerates_absent_marketplace(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+) {
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_claude_with_marketplace_remove_failing();
+    TestRepo::setup_plugin_installed(temp_home.path());
+    // No `known_marketplaces.json`, so the marketplace the removal failed on
+    // is already gone.
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "plugins", "claude", "uninstall", "--yes"])
+            .current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+/// The Codex counterpart: a second `uninstall` succeeds.
+#[rstest]
+fn test_plugins_codex_uninstall_tolerates_absent_marketplace(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+) {
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_codex_with_marketplace_remove_failing();
+    // No `config.toml`, so codex has no marketplace left to remove.
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "plugins", "codex", "uninstall", "--yes"])
+            .current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+/// The Codex counterpart: a marketplace that survives the removal still errors.
+#[rstest]
+fn test_plugins_codex_uninstall_surfaces_marketplace_remove_failure(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+) {
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_codex_with_marketplace_remove_failing();
+    TestRepo::setup_codex_marketplace_configured(temp_home.path());
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "plugins", "codex", "uninstall", "--yes"])
+            .current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
 #[test]
 fn test_codex_plugin_metadata_is_valid_json() {
     let project_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -5846,6 +5914,10 @@ fn test_plugins_claude_uninstall_second_step_fails(mut repo: TestRepo, temp_home
     repo.setup_mock_ci_tools_unauthenticated();
     repo.setup_mock_claude_installed();
     TestRepo::setup_plugin_installed(temp_home.path());
+    // The marketplace is still configured after the removal fails, which is
+    // what makes this a genuine failure rather than the already-gone state
+    // `test_plugins_claude_uninstall_tolerates_absent_marketplace` covers.
+    TestRepo::setup_claude_marketplace_configured(temp_home.path());
 
     // Plugin uninstall succeeds and only the marketplace removal that follows
     // it fails, so the error the command surfaces can come from nothing else.

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -4367,6 +4367,58 @@ fn test_plugins_claude_uninstall_tolerates_absent_marketplace(
     });
 }
 
+/// The Claude counterpart of the key-absent case: `known_marketplaces.json`
+/// exists because the user has other marketplaces, and worktrunk's entry is
+/// gone.
+#[rstest]
+fn test_plugins_claude_uninstall_tolerates_marketplace_removed_from_config(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+) {
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_claude_with_marketplace_remove_failing();
+    TestRepo::setup_plugin_installed(temp_home.path());
+    TestRepo::setup_claude_marketplaces(
+        temp_home.path(),
+        TestRepo::CLAUDE_MARKETPLACES_WITHOUT_WORKTRUNK,
+    );
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "plugins", "claude", "uninstall", "--yes"])
+            .current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+/// A `known_marketplaces.json` that will not parse cannot say the marketplace
+/// is gone, so the removal's failure stands. This is the shape-drift guard: if
+/// the file ever grows a wrapper the way `installed_plugins.json` has one,
+/// uninstall reports the harness's error rather than a silent success.
+#[rstest]
+fn test_plugins_claude_uninstall_surfaces_failure_when_config_unreadable(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+) {
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_claude_with_marketplace_remove_failing();
+    TestRepo::setup_plugin_installed(temp_home.path());
+    TestRepo::setup_claude_marketplaces(temp_home.path(), "{\"worktrunk\":");
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "plugins", "claude", "uninstall", "--yes"])
+            .current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
 /// The Codex counterpart: a second `uninstall` succeeds.
 #[rstest]
 fn test_plugins_codex_uninstall_tolerates_absent_marketplace(
@@ -4396,7 +4448,62 @@ fn test_plugins_codex_uninstall_surfaces_marketplace_remove_failure(
 ) {
     repo.setup_mock_ci_tools_unauthenticated();
     repo.setup_mock_codex_with_marketplace_remove_failing();
-    TestRepo::setup_codex_marketplace_configured(&temp_home.path().join(".codex"));
+    TestRepo::setup_codex_config(
+        &temp_home.path().join(".codex"),
+        TestRepo::CODEX_CONFIG_WITH_WORKTRUNK,
+    );
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "plugins", "codex", "uninstall", "--yes"])
+            .current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+/// The state a second `uninstall` actually lands in: `config.toml` is still
+/// there, holding the settings Codex keeps beside its marketplaces, and only
+/// worktrunk's table is gone. That is the key-absent answer rather than the
+/// missing-file one the test above covers.
+#[rstest]
+fn test_plugins_codex_uninstall_tolerates_marketplace_removed_from_config(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+) {
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_codex_with_marketplace_remove_failing();
+    TestRepo::setup_codex_config(
+        &temp_home.path().join(".codex"),
+        TestRepo::CODEX_CONFIG_WITHOUT_WORKTRUNK,
+    );
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "plugins", "codex", "uninstall", "--yes"])
+            .current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+/// A `config.toml` that will not parse cannot say the marketplace is gone, so
+/// the removal's failure stands rather than being reported as success.
+#[rstest]
+fn test_plugins_codex_uninstall_surfaces_failure_when_config_unreadable(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+) {
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_codex_with_marketplace_remove_failing();
+    TestRepo::setup_codex_config(
+        &temp_home.path().join(".codex"),
+        "[marketplaces.worktrunk\n",
+    );
 
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
@@ -4422,7 +4529,7 @@ fn test_plugins_codex_uninstall_reads_codex_home(mut repo: TestRepo, temp_home: 
     // lookup that ignored the variable would find no config and read the
     // failed removal as "already gone".
     let codex_home = TempDir::new().unwrap();
-    TestRepo::setup_codex_marketplace_configured(codex_home.path());
+    TestRepo::setup_codex_config(codex_home.path(), TestRepo::CODEX_CONFIG_WITH_WORKTRUNK);
 
     let mut cmd = repo.wt_command();
     cmd.args(["config", "plugins", "codex", "uninstall", "--yes"])
@@ -5946,7 +6053,10 @@ fn test_plugins_claude_uninstall_second_step_fails(mut repo: TestRepo, temp_home
     // The marketplace is still configured after the removal fails, which is
     // what makes this a genuine failure rather than the already-gone state
     // `test_plugins_claude_uninstall_tolerates_absent_marketplace` covers.
-    TestRepo::setup_claude_marketplace_configured(temp_home.path());
+    TestRepo::setup_claude_marketplaces(
+        temp_home.path(),
+        TestRepo::CLAUDE_MARKETPLACES_WITH_WORKTRUNK,
+    );
 
     // Plugin uninstall succeeds and only the marketplace removal that follows
     // it fails, so the error the command surfaces can come from nothing else.

--- a/tests/snapshots/integration__integration_tests__config_show__plugins_claude_uninstall_surfaces_failure_when_config_reshaped.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__plugins_claude_uninstall_surfaces_failure_when_config_reshaped.snap
@@ -1,0 +1,68 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - plugins
+    - claude
+    - uninstall
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "1"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mUninstalling plugin...[39m
+[36m◎[39m [36mRemoving Claude Code plugin marketplace...[39m
+[31m✗[39m [31mclaude plugin marketplace remove worktrunk failed (exit 1)[39m
+[107m [0m error: marketplace remove failed

--- a/tests/snapshots/integration__integration_tests__config_show__plugins_claude_uninstall_surfaces_failure_when_config_unreadable.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__plugins_claude_uninstall_surfaces_failure_when_config_unreadable.snap
@@ -1,0 +1,68 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - plugins
+    - claude
+    - uninstall
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "1"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mUninstalling plugin...[39m
+[36m◎[39m [36mRemoving Claude Code plugin marketplace...[39m
+[31m✗[39m [31mclaude plugin marketplace remove worktrunk failed (exit 1)[39m
+[107m [0m error: marketplace remove failed

--- a/tests/snapshots/integration__integration_tests__config_show__plugins_claude_uninstall_tolerates_absent_marketplace.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__plugins_claude_uninstall_tolerates_absent_marketplace.snap
@@ -1,0 +1,67 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - plugins
+    - claude
+    - uninstall
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "1"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mUninstalling plugin...[39m
+[36m◎[39m [36mRemoving Claude Code plugin marketplace...[39m
+[32m✓[39m [32mPlugin & marketplace removed[39m

--- a/tests/snapshots/integration__integration_tests__config_show__plugins_claude_uninstall_tolerates_marketplace_removed_from_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__plugins_claude_uninstall_tolerates_marketplace_removed_from_config.snap
@@ -1,0 +1,67 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - plugins
+    - claude
+    - uninstall
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "1"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mUninstalling plugin...[39m
+[36m◎[39m [36mRemoving Claude Code plugin marketplace...[39m
+[32m✓[39m [32mPlugin & marketplace removed[39m

--- a/tests/snapshots/integration__integration_tests__config_show__plugins_codex_uninstall_surfaces_failure_when_config_reshaped.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__plugins_codex_uninstall_surfaces_failure_when_config_reshaped.snap
@@ -1,0 +1,68 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - plugins
+    - codex
+    - uninstall
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "1"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mUninstalling plugin...[39m
+[36m◎[39m [36mRemoving Codex plugin marketplace...[39m
+[31m✗[39m [31mcodex plugin marketplace remove worktrunk failed (exit 1)[39m
+[107m [0m error: marketplace remove failed

--- a/tests/snapshots/integration__integration_tests__config_show__plugins_codex_uninstall_surfaces_failure_when_config_unreadable.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__plugins_codex_uninstall_surfaces_failure_when_config_unreadable.snap
@@ -1,0 +1,68 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - plugins
+    - codex
+    - uninstall
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "1"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mUninstalling plugin...[39m
+[36m◎[39m [36mRemoving Codex plugin marketplace...[39m
+[31m✗[39m [31mcodex plugin marketplace remove worktrunk failed (exit 1)[39m
+[107m [0m error: marketplace remove failed

--- a/tests/snapshots/integration__integration_tests__config_show__plugins_codex_uninstall_surfaces_marketplace_remove_failure.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__plugins_codex_uninstall_surfaces_marketplace_remove_failure.snap
@@ -1,0 +1,68 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - plugins
+    - codex
+    - uninstall
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "1"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mUninstalling plugin...[39m
+[36m◎[39m [36mRemoving Codex plugin marketplace...[39m
+[31m✗[39m [31mcodex plugin marketplace remove worktrunk failed (exit 1)[39m
+[107m [0m error: marketplace remove failed

--- a/tests/snapshots/integration__integration_tests__config_show__plugins_codex_uninstall_tolerates_absent_marketplace.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__plugins_codex_uninstall_tolerates_absent_marketplace.snap
@@ -1,0 +1,67 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - plugins
+    - codex
+    - uninstall
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "1"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mUninstalling plugin...[39m
+[36m◎[39m [36mRemoving Codex plugin marketplace...[39m
+[32m✓[39m [32mCodex plugin & marketplace removed[39m

--- a/tests/snapshots/integration__integration_tests__config_show__plugins_codex_uninstall_tolerates_marketplace_removed_from_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__plugins_codex_uninstall_tolerates_marketplace_removed_from_config.snap
@@ -1,0 +1,67 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - plugins
+    - codex
+    - uninstall
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "1"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mUninstalling plugin...[39m
+[36m◎[39m [36mRemoving Codex plugin marketplace...[39m
+[32m✓[39m [32mCodex plugin & marketplace removed[39m


### PR DESCRIPTION
`wt config plugins codex uninstall` fails when run twice. `#4019` made both harnesses' uninstall remove the marketplace after the plugin, and `plugin marketplace remove` exits non-zero when the marketplace is not configured — which is the state uninstall is trying to reach. So the second run reports a failure having nothing left to do. The Claude side has the same shape and is only masked by its `is_plugin_installed` early return, which returns before the marketplace step.

Measured against the real CLIs, each in a throwaway config dir:

| command | target absent | exit |
| --- | --- | --- |
| `claude plugin marketplace remove worktrunk` | `Marketplace 'worktrunk' not found` | 1 |
| `claude plugin uninstall worktrunk@worktrunk` | `not found in installed plugins` | 1 |
| `codex plugin marketplace remove worktrunk` | `is not configured or installed` | 1 |
| `codex plugin remove worktrunk@worktrunk` | reports removed | 0 |

`codex plugin remove` tolerating an absent plugin is what `#4019`'s "Superseded during review" note established; the marketplace removal beside it does not, which is what this fixes.

`run_plugin_removal` runs the removal and, when it fails, asks the harness's own config whether the marketplace is still there. The answer is three-way. A config the harness has never written records no marketplaces, so its absence is a confident `Some(false)` and the command succeeds. A marketplace still present is `Some(true)`, a genuine failure, and the harness's stderr surfaces in the gutter exactly as before. A config that exists and will not read or parse is `None`, and the error stands there too: a reader that cannot see the marketplace has not established that the removal worked.

That third answer is what keeps the fix from failing open, and it has to rest on the file's shape rather than on parsing alone. A key lookup answers "absent" for any JSON that simply lacks the key, so `known_marketplaces.json` reshaped the way the `installed_plugins.json` beside it wraps its map in a `version` key would parse, miss, and report a confident no — every genuine failure silently reported as success for as long as the shape held. The Claude reader therefore requires every value to be a marketplace object; the Codex reader rules out the one shape available to it, a `marketplaces` that is not a table, and claims nothing more, since a fresh `config.toml` legitimately has no such key. Both ask `try_exists` rather than `exists`, which reports `false` for a directory it cannot stat.

The removal runs in every case, so the `?` preview stays an accurate list of the commands the uninstall spawns, which `test_plugins_claude_prompt_previews_commands` pins.

`is_marketplace_configured` reads `known_marketplaces.json` for Claude, beside the `installed_plugins.json` that `is_plugin_installed` already reads, and Codex's `[marketplaces.<name>]` table in `config.toml`.

<details><summary>Tests, and one existing test whose setup changed</summary>

Each harness gets five cases, differing only in what the config holds: no config file, a config holding a different marketplace, a config holding worktrunk, a config that will not parse, and a config reshaped so it parses but no longer means what the reader expects. The middle one is the state a second `uninstall` actually lands in — Codex keeps its model and other settings in `config.toml`, and a Claude user with any other marketplace still has a `known_marketplaces.json` — so it, not the missing-file case, is the branch this fix exists for. Mock helpers fail only the marketplace removal, so the cases differ in config state alone, and the fixtures take the file body.

`test_plugins_claude_uninstall_second_step_fails` needed a configured marketplace added to its setup. Without one it had become the already-absent case, so it would have asserted success while its doc comment says the error surfaces. With the fixture its snapshot is unchanged from before this branch.

Tests drop an ambient `CODEX_HOME` rather than pinning one, so the Codex config lookup stays inside the temp home the way `CLAUDE_CONFIG_DIR` already does. Removing it keeps the variable out of every snapshot's env block, where pinning it would have churned each one and needed a new redaction. A separate test then points `CODEX_HOME` at a directory holding the only copy of the marketplace record, so the lookup has to follow the variable to find it; it asserts on the exit status rather than a snapshot, for that same reason.

The lookups carry no unreachable arms. `codex_config_dir` does not expand a leading `~/`, which was mirrored from `claude_config_dir` — where the comment explains a literal `~` only arrives when the variable is set outside a shell — and nothing sets Codex's that way here. Both readers fold their early returns into the paths the tests drive: resolving the config dir and reading the file are one `and_then`, so the missing-file case covers the `else` arm, and a malformed file falls out of `is_ok_and` rather than a `let ... else` of its own.

Local gate: `cargo fmt --check`, `cargo clippy --all-targets --all-features`, `cargo test --lib --bins`, `cargo test --test integration` (2090 passed), and `pre-commit run --all-files`.

</details>

> _This was written by Claude Code on behalf of max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
