### PR TITLE
Verify changelog claims against their own sources, and gate on a clean run

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -235,8 +235,9 @@ Verify these changelog entries for version X.Y.Z are accurate.
 Previous version: [e.g., v0.1.9]
 Commits to check: git log v<previous>..HEAD
 
-Entries to verify:
-[paste drafted entries]
+Entries to verify: the top section of CHANGELOG.md as it stands on disk. Read it
+there rather than from a paste:
+awk '/^## /{if (f) exit; f=1} f' CHANGELOG.md
 
 Verify claim by claim, not entry by entry: an entry carries several independent
 claims, and one verdict over the whole entry waves through every claim that is not
@@ -272,7 +273,9 @@ Report format:
   Suggested fix: [if needed]
 ```
 
-**The pass ends on a clean run, not on the first run's findings.** A rewrite the verifier suggests is a new draft with no more evidence behind it than one you wrote yourself, so applying it leaves that entry unverified again. An entry you edit while the pass runs is in the same state. Re-run the verifier over `CHANGELOG.md` as it stands, never a scratch copy of the draft, and finalize only once a run comes back clean.
+**The pass ends on a clean run, not on the first run's findings.** A rewrite the verifier suggests is a new draft with no more evidence behind it than one you wrote yourself, so applying it leaves that entry unverified again. An entry you edit while the pass runs is in the same state. Re-run the verifier over the section as it now stands, and finalize only once a run comes back clean.
+
+`evals/README.md` beside this skill holds four entries from a shipped release, three of them wrong, for scoring a change to this template against what the last wording missed.
 
 **If verification finds problems:** Escalate to the user. Show them the subagent's findings and ask how to proceed. Don't attempt to resolve ambiguous changelog entries autonomously — the user knows the intent behind their changes better than you do.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -227,14 +227,6 @@ Link when there's substantial documentation the user would benefit from reading 
 
 **The gate cuts both ways.** Checking only accuracy pushes every entry longer: "understates" and "not covered" have no counterweight, so each pass adds and none subtracts. That asymmetry is what drove the ratchet above. An entry that is too long, too internal, or ranked above one more readers will notice is reported on the same footing as one that is wrong.
 
-The subagent should:
-1. Take the list of drafted changelog entries
-2. For each entry, find the commit(s) it describes and read the actual diff
-3. Verify the entry accurately describes what changed
-4. Check for missing changes that should be documented
-5. Check each entry against the length ceiling and the ordering rule
-6. Report inaccuracies, omissions, overlong entries, and misordering
-
 **Subagent prompt template:**
 
 ```
@@ -246,12 +238,23 @@ Commits to check: git log v<previous>..HEAD
 Entries to verify:
 [paste drafted entries]
 
-For EACH entry:
+Verify claim by claim, not entry by entry: an entry carries several independent
+claims, and one verdict over the whole entry waves through every claim that is not
+its headline.
+
 1. Find the relevant commit(s) using git log and git show
-2. Read the actual diff, not just the commit message
-3. Confirm the entry accurately describes the user-facing change
-4. Flag if the entry overstates, understates, or misdescribes the change
-5. Flag if the entry runs over 60 words (80 for one of the two or three headline
+2. Read the diff, not the commit message. The diff settles what changed. It does
+   not settle what the behavior was before, what the user sees, or what a file it
+   doesn't touch does. Settle a "previously" / "no longer" / "so X broke" claim by
+   reading the old file (`git show <sha>^:<path>`) and confirming the old behavior
+   there. The new code's handling of the old case is not that confirmation: a case
+   added together with a comment about why it produces nothing reads in a diff
+   exactly like a case that used to produce something. Settle a claim about output
+   or a version floor against the rendered output and the docs, and a claim about
+   another component against that component's own file
+3. Flag any claim its source does not support, whether it overstates,
+   understates, or misdescribes
+4. Flag if the entry runs over 60 words (80 for one of the two or three headline
    entries), restates the PR description, or explains mechanism the reader cannot
    act on — report these as seriously as an inaccuracy, and quote a shorter
    rewrite that keeps every user-facing claim
@@ -265,11 +268,11 @@ Report format:
 - Entry: [entry text]
   Status: ✅ Accurate / ⚠️ Needs revision / ❌ Incorrect
   Length: [word count] — ✅ / ⚠️ over ceiling
-  Evidence: [what you found in the diff]
+  Evidence: [for each claim, the source you read and what it said]
   Suggested fix: [if needed]
 ```
 
-**Do not finalize the changelog until the subagent confirms every entry is accurate and within the ceiling.**
+**The pass ends on a clean run, not on the first run's findings.** A rewrite the verifier suggests is a new draft with no more evidence behind it than one you wrote yourself, so applying it leaves that entry unverified again. An entry you edit while the pass runs is in the same state. Re-run the verifier over `CHANGELOG.md` as it stands, never a scratch copy of the draft, and finalize only once a run comes back clean.
 
 **If verification finds problems:** Escalate to the user. Show them the subagent's findings and ask how to proceed. Don't attempt to resolve ambiguous changelog entries autonomously — the user knows the intent behind their changes better than you do.
 

--- a/.claude/skills/release/evals/README.md
+++ b/.claude/skills/release/evals/README.md
@@ -1,0 +1,21 @@
+# Changelog-verification cases
+
+Four entries from a shipped release, three of which reached users wrong. They
+score the "MANDATORY: Verify Each Changelog Entry" prompt template. Run the template as a subagent prompt over the section below and check
+which of the three it reports.
+
+Both the old and the current wording found all three when handed only these four
+entries, so run the template over the whole section, with the earlier per-group
+notes offered as a map. The cases measure attention spread across 29 entries, a
+missing-entries sweep, and the attribution checks.
+
+```bash
+git show v0.77.0:CHANGELOG.md | awk '/^## 0\.77\.0/{f=1} /^## 0\.76\.0/{exit} f'
+```
+
+| Case | Entry | The claim | What the source says |
+|------|-------|-----------|----------------------|
+| Before-state, with a confirming-looking diff | `wt list --format=json` gains a `marker` field | "`state` no longer carries `detached`" | `git show 981a207e2^:src/commands/list/model/state.rs` has no `Detached` variant — the PR adds it. The diff's no-op arm for `Detached` reads like the removal of a case that used to emit something. |
+| Truthmaker outside the diff | `wt config state marker` set and clear no-op | "an agent plugin's hooks failed on every event" | Every shipped marker hook ends `\|\| true` (`git grep 'state marker' v0.76.0 -- plugins hooks`), so the hook exited 0. `wt` printed a git error and exited 1. |
+| Non-headline clause, settled in the diff | The FAQ lists the files Worktrunk writes | "for Claude Code, Codex, OpenCode, Pi, and Gemini" | The FAQ's new table has three rows. Gemini appears nowhere; Codex appears only in the line saying its install writes nothing. |
+| Guardrail | LLM commit messages keep diffs for quoted paths | all of it | Accurate. A run that calls this entry wrong has gone too far. |

--- a/.claude/skills/release/evals/README.md
+++ b/.claude/skills/release/evals/README.md
@@ -14,6 +14,10 @@ release is in progress.
 git worktree add /tmp/wt-eval-0.77.0 v0.77.0   # remove it afterwards
 ```
 
+That checkout carries this skill at `v0.77.0` too, whose template is the one
+being replaced. Pass the arm's template as the prompt and withhold the `Skill`
+tool, so the run cannot load the old one off disk instead.
+
 Offer the run the notes from the per-group agents as a map, the way a release
 does. Handed only these four entries every wording found all three, so what the
 cases measure is attention spread across 29 entries, a missing-entries sweep,

--- a/.claude/skills/release/evals/README.md
+++ b/.claude/skills/release/evals/README.md
@@ -1,21 +1,27 @@
 # Changelog-verification cases
 
 Four entries from a shipped release, three of which reached users wrong. They
-score the "MANDATORY: Verify Each Changelog Entry" prompt template. Run the template as a subagent prompt over the section below and check
-which of the three it reports.
+score the "MANDATORY: Verify Each Changelog Entry" prompt template: run it as a
+subagent prompt and check which of the three it reports.
 
-Both the old and the current wording found all three when handed only these four
-entries, so run the template over the whole section, with the earlier per-group
-notes offered as a map. The cases measure attention spread across 29 entries, a
-missing-entries sweep, and the attribution checks.
+Run it over the whole 29-entry section, with the earlier per-group notes offered
+as a map. Handed only these four entries every wording found all three, so what
+the cases measure is attention spread across the section, a missing-entries
+sweep, and the attribution checks.
 
 ```bash
 git show v0.77.0:CHANGELOG.md | awk '/^## 0\.77\.0/{f=1} /^## 0\.76\.0/{exit} f'
 ```
 
+None of them has its truthmaker wholly outside the commit, and that is hard to
+fix here: this repo's commits routinely restate the surrounding facts in added
+comments and doc lines, so the falsifying text usually arrives in the diff. Read
+the rows as scoring how much of the diff the verifier reads, not whether it goes
+looking beyond one.
+
 | Case | Entry | The claim | What the source says |
 |------|-------|-----------|----------------------|
 | Before-state, with a confirming-looking diff | `wt list --format=json` gains a `marker` field | "`state` no longer carries `detached`" | `git show 981a207e2^:src/commands/list/model/state.rs` has no `Detached` variant — the PR adds it. The diff's no-op arm for `Detached` reads like the removal of a case that used to emit something. |
-| Truthmaker outside the diff | `wt config state marker` set and clear no-op | "an agent plugin's hooks failed on every event" | Every shipped marker hook ends `\|\| true` (`git grep 'state marker' v0.76.0 -- plugins hooks`), so the hook exited 0. `wt` printed a git error and exited 1. |
+| Fact in the diff, in an added comment rather than the code | `wt config state marker` set and clear no-op | "an agent plugin's hooks failed on every event" | Every shipped marker hook ends `\|\| true` (`git grep 'state marker' v0.76.0 -- plugins hooks`), so the hook exited 0. `29a611b7c` says so in a comment it adds beside the fix, so a verifier that reads the whole diff has the contradiction without leaving it. |
 | Non-headline clause, settled in the diff | The FAQ lists the files Worktrunk writes | "for Claude Code, Codex, OpenCode, Pi, and Gemini" | The FAQ's new table has three rows. Gemini appears nowhere; Codex appears only in the line saying its install writes nothing. |
 | Guardrail | LLM commit messages keep diffs for quoted paths | all of it | Accurate. A run that calls this entry wrong has gone too far. |

--- a/.claude/skills/release/evals/README.md
+++ b/.claude/skills/release/evals/README.md
@@ -4,14 +4,20 @@ Four entries from a shipped release, three of which reached users wrong. They
 score the "MANDATORY: Verify Each Changelog Entry" prompt template: run it as a
 subagent prompt and check which of the three it reports.
 
-Run it over the whole 29-entry section, with the earlier per-group notes offered
-as a map. Handed only these four entries every wording found all three, so what
-the cases measure is attention spread across the section, a missing-entries
-sweep, and the attribution checks.
+The template reads the top section of `CHANGELOG.md` on disk, so run the arm in a
+checkout at `v0.77.0`, where that section is the 29 entries these cases come
+from. Run the template unedited: pointing it at the section some other way scores
+a prompt nobody ships, and the section it would otherwise read is whatever
+release is in progress.
 
 ```bash
-git show v0.77.0:CHANGELOG.md | awk '/^## 0\.77\.0/{f=1} /^## 0\.76\.0/{exit} f'
+git worktree add /tmp/wt-eval-0.77.0 v0.77.0   # remove it afterwards
 ```
+
+Offer the run the notes from the per-group agents as a map, the way a release
+does. Handed only these four entries every wording found all three, so what the
+cases measure is attention spread across 29 entries, a missing-entries sweep,
+and the attribution checks.
 
 None of them has its truthmaker wholly outside the commit, and that is hard to
 fix here: this repo's commits routinely restate the surrounding facts in added


### PR DESCRIPTION
The v0.77.0 changelog verification pass reported 16 accurate, 6 needing revision, 0 incorrect. Eleven factual errors reached users anyway and were corrected in #4050. This changes the verification section so the pass covers the text that ships.

Two mechanisms produced the eleven, both visible in the pass's own report.

**Five of the errors were sentences the verifier itself wrote.** The template asks it to "quote a shorter rewrite", and the section's gate read "do not finalize until the subagent confirms every entry" — a gate you pass once. So the rewrites were applied and shipped with nothing having read them. The gate is now a clean run over `CHANGELOG.md` as it stands, and the text says why: a rewrite the verifier suggests is a new draft with no more evidence behind it than one you wrote yourself.

**Four were non-headline clauses inside entries stamped accurate.** The FAQ entry is the clearest: the verifier's evidence line says "three paths" and its verdict says accurate, under an entry claiming five agents. The template now verifies claim by claim rather than entry by entry, and its report format asks for the source read per claim, so a contradiction like that one lands on the page. The others were claims the diff cannot settle — a prior behavior, an untouched file, rendered output, a documented version floor — against a template whose one strong instruction ("read the actual diff") installed the diff as the sole source.

**The template also said "[paste drafted entries]" while the gate below it said to re-run over `CHANGELOG.md` as it stands** — the same drift channel one layer down, and how the failing pass came to verify a draft the working tree had already moved past. It now names the extraction one-liner the section already carries, so the rule is a mechanism rather than an instruction, and the gate drops the clause the template enforces. Found in review.

The six-step list that duplicated the prompt template below it is gone, so the section's line count is flat.

<details>
<summary>Measurement: A/B over the shipped 29-entry section, two runs per arm</summary>

Each arm ran the verification template as a subagent prompt over the whole v0.77.0 section, with the earlier per-group notes offered as a map — the load the failing pass had. Handed only the four scenario entries, every wording found everything, so that design measured nothing; attention spread across 29 entries is the variable.

| scenario | old | first draft | shipped |
|---|---|---|---|
| before-state claim, diff looks confirming | 0/2 | 0/2 | **1/2** |
| falsifying fact in an added comment | 1/2 | 2/2 | 1/2 |
| non-headline clause, settled in the diff | 0/2 | **1/2** | **2/2** |
| accurate entry stays clean (guardrail) | 2/2 | 2/2 | 1/2, one soft scope flag |

The first draft of step 2 failed the before-state case in both runs, so it was sharpened and retested rather than shipped on the strength of reading well. The cases are kept in `evals/README.md`.

No case has its truthmaker wholly outside the commit, and that is hard to arrange here: this repo's commits routinely restate the surrounding facts in added comments and doc lines, so the falsifying text usually arrives in the diff. The rows score how much of the diff the verifier reads, not whether it goes looking beyond one. The second row was labelled "truthmaker outside the diff" until review pointed out that `29a611b7c` states the fact in a comment it adds beside the fix.

The arms were run with the section pasted into the prompt, so the measurement covers the verification procedure rather than how the entries arrive. Now that the template resolves its own input, `evals/README.md` runs the arm in a checkout at `v0.77.0`, where the top section is that same 29 entries — so the template runs unedited. Review caught that the first version of this change left the harness scoring `## Unreleased` and reporting a clean pass.

The clean-run gate is not in that table. It changes the loop rather than the subagent prompt, so two arms of the prompt cannot separate it; it is argued structurally.

</details>

> _This was written by Claude Code on behalf of max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
