### PR TITLE
Confirm the write when wt config update --output names a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improved
 
-- **`wt config update --output <path>` confirms the write**: it now prints `✓ Wrote user config migration @ ~/migrated.toml`, so a command whose only effect is the file it wrote now says where that file is. Writing to stdout with `--output=-` stays silent, since the artifact is right there. ([#PRNUM](https://github.com/max-sixty/worktrunk/pull/PRNUM))
+- **`wt config update --output <path>` confirms the write**: it now prints `✓ Wrote user config migration @ ~/migrated.toml`, so a command whose only effect is the file it wrote now says where that file is. Writing to stdout with `--output=-` stays silent, since the artifact is right there. ([#4053](https://github.com/max-sixty/worktrunk/pull/4053))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improved
+
+- **`wt config update --output <path>` confirms the write**: it now prints `✓ Wrote user config migration @ ~/migrated.toml`, so a command whose only effect is the file it wrote now says where that file is. Writing to stdout with `--output=-` stays silent, since the artifact is right there. ([#PRNUM](https://github.com/max-sixty/worktrunk/pull/PRNUM))
+
 ### Fixed
 
 - **`wt config plugins claude uninstall` / `codex uninstall` no longer report success over a marketplace that is still there**: to tell an already-removed marketplace from a removal that failed, uninstall used to read the harness's own config file. A file or key the harness renamed reads as an absence there, so every failed removal would have printed `Plugin & marketplace removed` and exited 0. It now asks `claude` / `codex plugin marketplace list --json`, and an answer it cannot read leaves the harness's error standing. ([#4048](https://github.com/max-sixty/worktrunk/pull/4048))

--- a/src/commands/config/update.rs
+++ b/src/commands/config/update.rs
@@ -106,51 +106,57 @@ pub fn handle_config_update(yes: bool, output: Option<PathBuf>) -> anyhow::Resul
 }
 
 /// Write the migration artifact to a path, or to stdout when the path is `-`.
+///
+/// The two destinations differ in what they can carry, so they run as separate
+/// paths rather than one path testing `-` at each step. Stdout labels and
+/// concatenates every candidate and needs no confirmation — the artifact is
+/// right there. A file takes exactly one migration, so the checks below and
+/// the confirmation can name the config it came from.
 fn write_migrated_output(output: &Path, candidates: &[UpdateCandidate]) -> anyhow::Result<()> {
-    let stdout = output == Path::new("-");
-
-    if candidates.is_empty() {
-        if !stdout {
-            eprintln!("{}", info_message("No deprecated settings found"));
+    if output == Path::new("-") {
+        for candidate in candidates {
+            eprint!("{}", format_dropped_approvals_warning(candidate));
         }
+        print!("{}", format_migrated_output(candidates));
         return Ok(());
     }
 
-    if !stdout && candidates.len() > 1 {
+    if candidates.is_empty() {
+        eprintln!("{}", info_message("No deprecated settings found"));
+        return Ok(());
+    }
+
+    let [candidate] = candidates else {
         bail!(cformat!(
             "Cannot write <bold>user config</> and <bold>project config</> migrations to one file; use <bold>--output=-</> to inspect both or run <bold>wt config update</> to apply them in place"
         ));
-    }
+    };
 
     let output = resolve_input_path(output);
-    if !stdout
-        && let Some(candidate) = candidates
-            .iter()
-            .filter(|candidate| drops_approved_commands(candidate))
-            .find(|candidate| paths_match(&output, &candidate.config_path))
-    {
+    if drops_approved_commands(candidate) && paths_match(&output, &candidate.config_path) {
         bail!(cformat!(
             "Cannot overwrite <bold>{}</> with <bold>--output</>; run <bold>wt config update</> to apply the migration in place",
             candidate.info.label().to_lowercase()
         ));
     }
 
-    for candidate in candidates {
-        eprint!("{}", format_dropped_approvals_warning(candidate));
-    }
+    eprint!("{}", format_dropped_approvals_warning(candidate));
 
     let artifact = format_migrated_output(candidates);
-    if stdout {
-        print!("{artifact}");
-        return Ok(());
-    }
-
     worktrunk::utils::write_atomically(&output, &artifact).with_context(|| {
         format!(
             "Failed to write output @ {}",
             format_path_for_display(&output)
         )
     })?;
+    eprintln!(
+        "{}",
+        success_message(format!(
+            "Wrote {} migration @ {}",
+            candidate.info.label().to_lowercase(),
+            format_path_for_display(&output)
+        ))
+    );
     Ok(())
 }
 

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -3565,7 +3565,13 @@ fn test_config_update_output_destinations_emit_same_config(repo: TestRepo) {
         .unwrap();
     assert!(file_output.status.success());
     assert!(file_output.stdout.is_empty());
-    assert!(file_output.stderr.is_empty());
+    let stderr = String::from_utf8_lossy(&file_output.stderr)
+        .ansi_strip()
+        .into_owned();
+    assert!(
+        stderr.contains("Wrote user config migration @") && stderr.contains("migrated.toml"),
+        "a file destination confirms the write, unlike stdout; got: {stderr}"
+    );
     assert_eq!(fs::read(destination).unwrap(), stdout_output.stdout);
     assert_eq!(fs::read_to_string(config_path).unwrap(), original);
 }


### PR DESCRIPTION
`wt config update --output <path>` writes the migration artifact to a file and then says nothing — no warnings, no diff, no path, no confirmation. The in-place form prints the deprecation warnings, a diff preview, and `✓ Updated user config`, so the export path was the one form of the command whose entire effect was invisible.

It now prints `✓ Wrote user config migration @ ~/migrated.toml` after the write. `--output=-` stays silent: the artifact is already on the terminal, and a confirmation on stderr would be noise next to it.

Naming the config in that line needs the single candidate bound, which the old shape couldn't do — so the two destinations are now separate paths rather than one path testing `-` at each of four steps. A file takes exactly one migration, which a `let`-else states directly, and the approvals-overwrite check drops its `filter().find()` over a slice that could only ever hold one element. Every destination × emptiness combination is unchanged apart from the new line, checked against the binary.

`test_config_update_output_destinations_emit_same_config` had pinned the old silence with `assert!(file_output.stderr.is_empty())`; it now asserts the confirmation names the destination, and still checks that both destinations emit identical bytes.

> _This was written by Claude Code on behalf of max-sixty_
