### PR TITLE
Trade changelog-verification mechanics for the stakes behind them

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -223,18 +223,18 @@ Link when there's substantial documentation the user would benefit from reading 
 
 ### MANDATORY: Verify Each Changelog Entry
 
-**After drafting changelog entries, you MUST spawn a subagent to verify each bullet point is accurate.** A correction made after the tag lands in `CHANGELOG.md` and not in the GitHub release body readers already have, so this pass is the last one whose findings reach them. It is worth as much time as it takes.
+**After drafting changelog entries, you MUST spawn a subagent to verify each bullet point is accurate.** The tag publishes this text as the GitHub release body, so a correction afterwards takes a follow-up PR to `CHANGELOG.md` and a hand-edit of the release page, and people have read the wrong line by then. This pass is worth as much time as it takes.
 
 **The gate cuts both ways.** Checking only accuracy pushes every entry longer: "understates" and "not covered" have no counterweight, so each pass adds and none subtracts. That asymmetry is what drove the ratchet above. An entry that is too long, too internal, or ranked above one more readers will notice is reported on the same footing as one that is wrong.
 
 **Subagent prompt template:**
 
 ```
-Verify these changelog entries for version X.Y.Z are accurate. They ship with the
-tag and are not revised afterwards, so a claim that goes unchecked here goes out to
-readers who act on it. Spend the time to read a source for each one: reading the
-entry and finding it plausible is not a check, because the entry was written from
-the same commits you are about to read.
+Verify these changelog entries for version X.Y.Z are accurate. They publish with
+the tag, and by the time anyone corrects a wrong line, readers have acted on it.
+Spend the time to read a source for each one: reading the entry and finding it
+plausible is not a check, because the entry was written from the same commits you
+are about to read.
 
 Previous version: [e.g., v0.1.9]
 Commits to check: git log v<previous>..HEAD
@@ -250,12 +250,15 @@ its headline.
 1. Find the relevant commit(s) using git log and git show
 2. Read the diff, not the commit message. The diff settles what changed, and
    nothing else: not what the behavior was before, not what the user sees, not
-   what a file it doesn't touch does. For those, go to the source that holds the
-   claim. Settle a "previously" / "no longer" / "so X broke" claim by reading
-   the old file (`git show <sha>^:<path>`) and confirming the old behavior
-   there. The new code's handling of the old case is not that confirmation: a
-   case added together with a comment about why it produces nothing reads in a
-   diff exactly like a case that used to produce something
+   what a file it doesn't touch does. Settle a "previously" / "no longer" / "so X
+   broke" claim by reading the old file (`git show <sha>^:<path>`) and confirming
+   the old behavior there. The new code's handling of the old case is not that
+   confirmation: a case added together with a comment about why it produces
+   nothing reads in a diff exactly like a case that used to produce something.
+   Some claims have no source in the commit at all — a version floor, what a
+   rendered page shows, how another component behaves. Read that source: the
+   rendered output, the other component's own file, the upstream project's own
+   releases
 3. Flag any claim its source does not support, whether it overstates,
    understates, or misdescribes
 4. Flag if the entry runs over 60 words (80 for one of the two or three headline

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -223,14 +223,18 @@ Link when there's substantial documentation the user would benefit from reading 
 
 ### MANDATORY: Verify Each Changelog Entry
 
-**After drafting changelog entries, you MUST spawn a subagent to verify each bullet point is accurate.** This is non-negotiable — changelog mistakes are a recurring problem.
+**After drafting changelog entries, you MUST spawn a subagent to verify each bullet point is accurate.** A correction made after the tag lands in `CHANGELOG.md` and not in the GitHub release body readers already have, so this pass is the last one whose findings reach them. It is worth as much time as it takes.
 
 **The gate cuts both ways.** Checking only accuracy pushes every entry longer: "understates" and "not covered" have no counterweight, so each pass adds and none subtracts. That asymmetry is what drove the ratchet above. An entry that is too long, too internal, or ranked above one more readers will notice is reported on the same footing as one that is wrong.
 
 **Subagent prompt template:**
 
 ```
-Verify these changelog entries for version X.Y.Z are accurate.
+Verify these changelog entries for version X.Y.Z are accurate. They ship with the
+tag and are not revised afterwards, so a claim that goes unchecked here goes out to
+readers who act on it. Spend the time to read a source for each one: reading the
+entry and finding it plausible is not a check, because the entry was written from
+the same commits you are about to read.
 
 Previous version: [e.g., v0.1.9]
 Commits to check: git log v<previous>..HEAD
@@ -244,15 +248,14 @@ claims, and one verdict over the whole entry waves through every claim that is n
 its headline.
 
 1. Find the relevant commit(s) using git log and git show
-2. Read the diff, not the commit message. The diff settles what changed. It does
-   not settle what the behavior was before, what the user sees, or what a file it
-   doesn't touch does. Settle a "previously" / "no longer" / "so X broke" claim by
-   reading the old file (`git show <sha>^:<path>`) and confirming the old behavior
-   there. The new code's handling of the old case is not that confirmation: a case
-   added together with a comment about why it produces nothing reads in a diff
-   exactly like a case that used to produce something. Settle a claim about output
-   or a version floor against the rendered output and the docs, and a claim about
-   another component against that component's own file
+2. Read the diff, not the commit message. The diff settles what changed, and
+   nothing else: not what the behavior was before, not what the user sees, not
+   what a file it doesn't touch does. For those, go to the source that holds the
+   claim. Settle a "previously" / "no longer" / "so X broke" claim by reading
+   the old file (`git show <sha>^:<path>`) and confirming the old behavior
+   there. The new code's handling of the old case is not that confirmation: a
+   case added together with a comment about why it produces nothing reads in a
+   diff exactly like a case that used to produce something
 3. Flag any claim its source does not support, whether it overstates,
    understates, or misdescribes
 4. Flag if the entry runs over 60 words (80 for one of the two or three headline
@@ -273,7 +276,7 @@ Report format:
   Suggested fix: [if needed]
 ```
 
-**The pass ends on a clean run, not on the first run's findings.** A rewrite the verifier suggests is a new draft with no more evidence behind it than one you wrote yourself, so applying it leaves that entry unverified again. An entry you edit while the pass runs is in the same state. Re-run the verifier over the section as it now stands, and finalize only once a run comes back clean.
+**The pass ends on a clean run, not on the first run's findings.** A rewrite the verifier suggests has no more evidence behind it than one you wrote yourself, and an entry you edit while the pass runs is in the same state — both leave that entry unverified. Re-run over the section as it now stands, and finalize only once a run comes back clean.
 
 `evals/README.md` beside this skill holds four entries from a shipped release, three of them wrong, for scoring a change to this template against what the last wording missed.
 


### PR DESCRIPTION
#4051 fixed the changelog-verification section by adding procedure. A procedure gets run literally and thinly, so this trades some of it back for why the pass matters, stated where each reader can see it.

**The subagent never reads SKILL.md.** Stakes stated there reach the agent that spawns the verifier and nothing else, so the prompt template gets its own opener: the entries publish with the tag, and by the time anyone corrects a wrong line readers have acted on it — and reading an entry and finding it plausible is not a check, because it was written from the same commits the verifier is about to read.

**SKILL.md's line now says what a late correction costs.** It replaces "This is non-negotiable — changelog mistakes are a recurring problem". The workflow builds the release body with `--notes-file` at tag time (`.github/workflows/release.yaml:381`), so a later `CHANGELOG.md` edit isn't picked up: correcting a published entry takes a follow-up PR *and* a hand-edit of the release page.

**Cut in exchange:** a sentence from the clean-run gate. Net +5 lines.

An earlier revision of this branch also cut step 2's guidance for claims whose source is outside the commit. The review caught that, and it's back — reworded, because the sentence I'd removed pointed at "the rendered output and the docs" and the docs would not have settled the OpenCode version floor that shipped wrong in v0.77.0. It now names the upstream project's own releases. `evals/README.md` states that none of its cases has a truthmaker outside the commit, so the suite could not have scored that cut in either direction.

<details>
<summary>Eval runs</summary>

Scored against `.claude/skills/release/evals/` — four entries from the v0.77.0 section, three of them wrong — run in a `v0.77.0` checkout with the `Skill` tool withheld, per that README.

| | before-state | hooks `\|\| true` | five agents vs three rows | guardrail |
|---|---|---|---|---|
| #4051's wording | 2/2 | 2/2 | 2/2 | held |
| first draft here | 1/2 | 2/2 | 2/2 | held |
| this branch | 2/3 | 3/3 | 3/3 | held |

The first draft had also dropped four words from step 2, "and confirming the old behavior there". Its failing run read the *new* file, found `json_output.rs` dropping `WorktreeState::Detached`, concluded "schema 1 only", and wrote a suggested fix that still claimed `state` no longer reports `detached` — reproducing the original error while flagging the entry. That clause is restored, and the one miss in the three runs after it failed the same way.

So the before-state case is 2/2 for #4051's wording and 2/3 for this one, which this design cannot separate: seven runs is far too few, and the case was already the weakest of the three when #4051 shipped it (0/2 before that PR's own fix, 1/2 after). What the eval supports is that relaxing the mechanics did not break the two solid cases, and that the four-word clause is load-bearing enough to keep. The argument for the stakes paragraphs is structural, not measured.

The guardrail entry was never called inaccurate in any of the seven runs. The runs predate the stakes correction below, which changes no instruction the cases exercise.

</details>

<details>
<summary>The stakes claim this PR opened with was wrong</summary>

The first version of this change claimed a post-tag correction reaches `CHANGELOG.md` and never the published release body, citing v0.77.0 as evidence. The review disputed it and was right: the published v0.77.0 body carries all 29 corrected entries, hand-edited after #4050. Diffed both ways, zero differences.

I had grepped the published body for "Claude Code, Codex, OpenCode", matched the Pi entry's legitimate "markers … like Claude Code, Codex, OpenCode, and Gemini", and read it as the FAQ entry's uncorrected error — a plausible-looking string taken for the source, which is the failure this PR is about.

Fixed in 4800a7547; only the mechanism that actually holds is claimed now.

</details>

> _This was written by Claude Code on behalf of max-sixty_
