### PR TITLE
fix: reject removed commits prompt variable

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -358,6 +358,9 @@
 # - `{{ commit_details }}` — list of commits being squashed; each renders as its subject and exposes `.subject` / `.body`
 # - `{{ target_branch }}` — merge target branch
 #
+# The old `commits` variable has been removed. Run `wt config update` to migrate existing prompt templates to `commit_details`.
+# Each detail still renders as its subject when printed directly; `.body` remains available separately.
+#
 # Default template:
 #
 # <!-- DEFAULT_SQUASH_TEMPLATE_START -->

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -479,6 +479,9 @@ Available variables (in addition to commit template variables):
 - `{{ commit_details }}` — list of commits being squashed; each renders as its subject and exposes `.subject` / `.body`
 - `{{ target_branch }}` — merge target branch
 
+The old `commits` variable has been removed. Run `wt config update` to migrate existing prompt templates to `commit_details`.
+Each detail still renders as its subject when printed directly; `.body` remains available separately.
+
 Default template:
 
 <!-- DEFAULT_SQUASH_TEMPLATE_START -->

--- a/docs/src/content/docs/llm-commits.md
+++ b/docs/src/content/docs/llm-commits.md
@@ -181,6 +181,10 @@ Diff:
 | `{{ user_guidance }}` | Rendered user `template-append` fragment (see below) |
 | `{{ project_guidance }}` | Rendered project `template-append` fragment (see below) |
 
+The old `commits` variable is removed. Prompt templates and append fragments that reference it fail with an error naming the template and its replacement, `commit_details`.
+Run `wt config update` to migrate existing configuration; a loop that prints each element directly keeps producing its subject.
+This removal takes effect with the release containing it, not by checking the current date. Older binaries retain their previous behavior.
+
 ### Template syntax
 
 Templates use [minijinja](https://docs.rs/minijinja/latest/minijinja/syntax/index.html), which supports:

--- a/plugins/worktrunk/skills/worktrunk/reference/config.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/config.md
@@ -471,6 +471,9 @@ Available variables (in addition to commit template variables):
 - `{{ commit_details }}` — list of commits being squashed; each renders as its subject and exposes `.subject` / `.body`
 - `{{ target_branch }}` — merge target branch
 
+The old `commits` variable has been removed. Run `wt config update` to migrate existing prompt templates to `commit_details`.
+Each detail still renders as its subject when printed directly; `.body` remains available separately.
+
 Default template:
 
 <!-- DEFAULT_SQUASH_TEMPLATE_START -->

--- a/plugins/worktrunk/skills/worktrunk/reference/llm-commits.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/llm-commits.md
@@ -158,6 +158,10 @@ Diff:
 | `{{ user_guidance }}` | Rendered user `template-append` fragment (see below) |
 | `{{ project_guidance }}` | Rendered project `template-append` fragment (see below) |
 
+The old `commits` variable is removed. Prompt templates and append fragments that reference it fail with an error naming the template and its replacement, `commit_details`.
+Run `wt config update` to migrate existing configuration; a loop that prints each element directly keeps producing its subject.
+This removal takes effect with the release containing it, not by checking the current date. Older binaries retain their previous behavior.
+
 ### Template syntax
 
 Templates use [minijinja](https://docs.rs/minijinja/latest/minijinja/syntax/index.html), which supports:

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -471,6 +471,9 @@ Available variables (in addition to commit template variables):
 - `{{ commit_details }}` — list of commits being squashed; each renders as its subject and exposes `.subject` / `.body`
 - `{{ target_branch }}` — merge target branch
 
+The old `commits` variable has been removed. Run `wt config update` to migrate existing prompt templates to `commit_details`.
+Each detail still renders as its subject when printed directly; `.body` remains available separately.
+
 Default template:
 
 <!-- DEFAULT_SQUASH_TEMPLATE_START -->

--- a/skills/worktrunk/reference/llm-commits.md
+++ b/skills/worktrunk/reference/llm-commits.md
@@ -158,6 +158,10 @@ Diff:
 | `{{ user_guidance }}` | Rendered user `template-append` fragment (see below) |
 | `{{ project_guidance }}` | Rendered project `template-append` fragment (see below) |
 
+The old `commits` variable is removed. Prompt templates and append fragments that reference it fail with an error naming the template and its replacement, `commit_details`.
+Run `wt config update` to migrate existing configuration; a loop that prints each element directly keeps producing its subject.
+This removal takes effect with the release containing it, not by checking the current date. Older binaries retain their previous behavior.
+
 ### Template syntax
 
 Templates use [minijinja](https://docs.rs/minijinja/latest/minijinja/syntax/index.html), which supports:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2416,6 +2416,9 @@ Available variables (in addition to commit template variables):
 - `{{ commit_details }}` — list of commits being squashed; each renders as its subject and exposes `.subject` / `.body`
 - `{{ target_branch }}` — merge target branch
 
+The old `commits` variable has been removed. Run `wt config update` to migrate existing prompt templates to `commit_details`.
+Each detail still renders as its subject when printed directly; `.body` remains available separately.
+
 Default template:
 
 <!-- DEFAULT_SQUASH_TEMPLATE_START -->

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -14,6 +14,10 @@
 //! one predicate and cannot drift. The table order is both the
 //! warning-emission order and the migration order.
 //!
+//! Retired prompt variables are checked by [`check_prompt_variables`] when a
+//! prompt is built, not when config is loaded. Their migration remains available
+//! to `wt config update`, and unrelated commands can still load the config.
+//!
 //! Detection is purely in-memory — nothing writes to the filesystem from a
 //! config load path. `check_and_migrate` returns the structurally migrated
 //! content (for serde) and a `DeprecationInfo` describing what needs fixing.
@@ -97,18 +101,36 @@ pub fn warnings_suppressed() -> bool {
 static WARNED_UNKNOWN_PATHS: LazyLock<Mutex<HashSet<PathBuf>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
 
+const RETIRED_COMMITS_VAR: (&str, &str) = ("commits", "commit_details");
+
 /// Mapping from deprecated variable name to its replacement
 const DEPRECATED_VARS: &[(&str, &str)] = &[
     ("repo_root", "repo_path"),
     ("worktree", "worktree_path"),
     ("main_worktree", "repo"),
     ("main_worktree_path", "primary_worktree_path"),
-    // Squash-template-only. The rename is a safe mechanical rewrite because each
+    // Retired prompt variable; retain the migration for existing configs. Each
     // `commit_details` element renders as its subject when printed bare, so a
     // migrated `{% for c in commit_details %}{{ c }}` reads identically to the
     // old `{% for c in commits %}{{ c }}` (see #2984 and `CommitDetailValue`).
-    ("commits", "commit_details"),
+    RETIRED_COMMITS_VAR,
 ];
+
+/// Reject retired prompt variables without matching literals or local bindings.
+/// Config loading and the migration rule stay independent of prompt rendering,
+/// so the suggested recovery command can still repair an existing config.
+pub fn check_prompt_variables(
+    template: &minijinja::Template<'_, '_>,
+    location: &str,
+) -> anyhow::Result<()> {
+    let (old, new) = RETIRED_COMMITS_VAR;
+    if template.undeclared_variables(false).contains(old) {
+        anyhow::bail!(cformat!(
+            "Template <bold>{location}</> uses removed variable <bold>{old}</>; use <bold>{new}</> (run <bold>wt config update</>)"
+        ));
+    }
+    Ok(())
+}
 
 /// Metadata for a deprecated top-level section key.
 #[derive(Debug)]
@@ -524,11 +546,11 @@ type SilentMigrateFn = fn(&mut toml_edit::DocumentMut) -> bool;
 enum DeprecationRule {
     /// Warns, and is rewritten on every config load before serde parses.
     Structural(MigrateFn),
-    /// Warns, but the deprecated form still works at runtime (deprecated
-    /// template variables resolve via [`normalize_template_vars`];
-    /// `approved-commands` is still a valid serde field), so the load path
-    /// leaves it alone. Rewritten only via [`compute_migrated_content`]
-    /// (`wt config show` / `wt config update`).
+    /// Warns without changing the loaded config. Template strings need an
+    /// explicit rewrite, including variables retired from prompt rendering;
+    /// `approved-commands` must be copied to approvals.toml before removal.
+    /// Rewritten only via [`compute_migrated_content`] (`wt config show` /
+    /// `wt config update`).
     UpdateOnly(MigrateFn),
     /// Silently-migrated rename: rewritten on every load like `Structural`,
     /// but with no warning by construction.
@@ -653,8 +675,8 @@ fn detect_deprecations_from_doc(doc: &toml_edit::DocumentMut) -> Deprecations {
 /// Run every rule in table order against `doc`, appending each rule's warning
 /// kinds to `kinds` and returning whether the document changed.
 ///
-/// The load pass excludes [`DeprecationRule::UpdateOnly`] rewrites (cosmetic
-/// or still-valid serde fields, so serde doesn't need them applied).
+/// The load pass excludes [`DeprecationRule::UpdateOnly`] rewrites: template
+/// strings and still-valid serde fields don't need rewriting for deserialization.
 /// Detection and [`compute_migrated_content`] run the update pass.
 fn apply_rules(doc: &mut toml_edit::DocumentMut, pass: RulePass, kinds: &mut Deprecations) -> bool {
     let mut modified = false;
@@ -1258,7 +1280,7 @@ fn migrate_negated_bool_doc(
 /// Returns true if any modifications were made.
 ///
 /// [`DeprecationRule::UpdateOnly`] rules are excluded — template variable
-/// renaming is cosmetic (would break `--var` overrides), and approved-commands
+/// renaming can change `--var` overrides, and approved-commands
 /// is still a valid serde field. They apply in [`compute_migrated_content`].
 fn migrate_content_doc(doc: &mut toml_edit::DocumentMut) -> bool {
     apply_rules(doc, RulePass::Load, &mut Vec::new())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -162,6 +162,7 @@ pub use deprecation::CheckAndMigrateResult;
 pub use deprecation::ConfigFileKind;
 pub use deprecation::DeprecationInfo;
 pub use deprecation::check_and_migrate;
+pub use deprecation::check_prompt_variables;
 pub use deprecation::compute_migrated_content;
 pub use deprecation::copy_approved_commands_to_approvals_file;
 pub use deprecation::format_deprecation_details;

--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -68,7 +68,7 @@ pub struct CommitGenerationConfig {
     pub template: Option<String>,
 
     /// Inline template for squash commit message prompt
-    /// Available variables: {{ commits }}, {{ target_branch }}, {{ branch }}, {{ repo }}
+    /// Available variables: {{ commit_details }}, {{ target_branch }}, {{ branch }}, {{ repo }}
     #[serde(default, rename = "squash-template")]
     pub squash_template: Option<String>,
 

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::path::Path;
 use std::sync::Arc;
-use worktrunk::config::CommitGenerationConfig;
+use worktrunk::config::{CommitGenerationConfig, check_prompt_variables};
 use worktrunk::git::{CommandError, CommitMessageDetail, ErrorExt, Repository, WorkingTree};
 use worktrunk::shell_exec::{Cmd, ShellConfig};
 
@@ -16,7 +16,7 @@ use minijinja::value::{Enumerator, Object, Value};
 ///
 /// It renders as its bare subject (`{{ detail }}` yields the subject line) so a
 /// template that iterates the list and prints the loop variable directly
-/// behaves exactly like the deprecated `commits` list of subject strings. That
+/// behaves exactly like the old `commits` list of subject strings. That
 /// equivalence is what lets `wt config update` migrate a `commits` template to
 /// `commit_details` as a plain identifier rename — no shape-changing hand edits
 /// (see #2984). The `.subject` and `.body` properties remain available for
@@ -584,8 +584,6 @@ enum TemplateType {
 ///   subject when printed bare and exposes `.subject` / `.body` properties.
 ///   Capped at [`MAX_SQUASH_COMMITS`]; the older tail is represented by one
 ///   synthetic "(N earlier commits omitted)" entry.
-/// - `commits`: Commit subjects being squashed (deprecated — see #2984;
-///   `wt config update` rewrites it to `commit_details`)
 /// - `target_branch`: Target branch for merge
 fn build_prompt(
     config: &CommitGenerationConfig,
@@ -593,10 +591,11 @@ fn build_prompt(
     context: &PromptContext<'_>,
 ) -> anyhow::Result<String> {
     // Get template source based on type
-    let (template, type_name) = match template_type {
+    let (template, type_name, location) = match template_type {
         TemplateType::Commit => (
             config.template.as_deref().unwrap_or(DEFAULT_TEMPLATE),
             "Template",
+            "commit.generation.template",
         ),
         TemplateType::Squash => (
             config
@@ -604,6 +603,7 @@ fn build_prompt(
                 .as_deref()
                 .unwrap_or(DEFAULT_SQUASH_TEMPLATE),
             "Squash template",
+            "commit.generation.squash-template",
         ),
     };
 
@@ -618,18 +618,9 @@ fn build_prompt(
     // Render template with minijinja - all variables available to all templates
     let env = Environment::new();
     let tmpl = env.template_from_str(template)?;
+    check_prompt_variables(&tmpl, location)?;
 
     // Reverse commits so they're in chronological order (oldest first).
-    //
-    // `commits` (a list of bare subject strings) is deprecated in favor of
-    // `commit_details` (see #2984). The deprecation warning and the
-    // `wt config update` rewrite both go through the standard config
-    // deprecation framework (`DEPRECATED_VARS`), so nothing is detected or
-    // warned here — `commits` is simply still rendered for templates that
-    // haven't migrated yet. The rename is safe because each `commit_details`
-    // element renders as its subject (see `CommitDetailValue`), so a migrated
-    // `{% for c in commit_details %}{{ c }}` reads identically to the old
-    // `{% for c in commits %}{{ c }}`.
     //
     // The list is capped at `MAX_SQUASH_COMMITS` — the one prompt input the
     // diff budget doesn't bound. Details arrive newest-first, so the newest
@@ -647,10 +638,6 @@ fn build_prompt(
     let details_chronological: Vec<&CommitMessageDetail> = synthetic_tail
         .iter()
         .chain(kept_details.iter().rev())
-        .collect();
-    let commits_chronological: Vec<&String> = details_chronological
-        .iter()
-        .map(|detail| &detail.subject)
         .collect();
     let commit_details_chronological: Vec<Value> = details_chronological
         .iter()
@@ -672,15 +659,15 @@ fn build_prompt(
     // own config); the project fragment is gated upstream and arrives here
     // as `context.project_append` (or `None` if declined). Empty string when
     // a source is absent — the templates gate the block on truthiness.
-    let render_fragment = |fragment: &str| -> anyhow::Result<String> {
+    let render_fragment = |fragment: &str, location: &str| -> anyhow::Result<String> {
         let frag_tmpl = env.template_from_str(fragment)?;
+        check_prompt_variables(&frag_tmpl, location)?;
         Ok(frag_tmpl.render(minijinja::context! {
             git_diff => context.git_diff,
             git_diff_stat => context.git_diff_stat,
             branch => context.branch,
             recent_commits => context.recent_commits.unwrap_or(&empty_commits),
             repo => context.repo_name,
-            commits => &commits_chronological,
             commit_details => &commit_details_chronological,
             target_branch => context.target_branch.unwrap_or(""),
         })?)
@@ -691,11 +678,11 @@ fn build_prompt(
         .map(str::trim)
         .filter(|s| !s.is_empty())
     {
-        Some(fragment) => render_fragment(fragment)?,
+        Some(fragment) => render_fragment(fragment, "user commit.generation.template-append")?,
         None => String::new(),
     };
     let project_guidance = match context.project_append {
-        Some(fragment) => render_fragment(fragment)?,
+        Some(fragment) => render_fragment(fragment, "project commit.generation.template-append")?,
         None => String::new(),
     };
 
@@ -705,7 +692,6 @@ fn build_prompt(
         branch => context.branch,
         recent_commits => context.recent_commits.unwrap_or(&empty_commits),
         repo => context.repo_name,
-        commits => commits_chronological,
         commit_details => commit_details_chronological,
         target_branch => context.target_branch.unwrap_or(""),
         user_guidance => user_guidance,
@@ -1030,6 +1016,7 @@ pub(crate) fn test_commit_generation(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ansi_str::AnsiStr;
     use insta::assert_snapshot;
 
     /// `render_llm_invocation` should wrap the command through the platform shell with
@@ -1624,13 +1611,99 @@ mod tests {
         "#);
     }
 
+    #[rstest::rstest]
+    #[case::bare("{{ commits }}")]
+    #[case::loop_source("{% for c in commits %}{{ c }}{% endfor %}")]
+    #[case::filter("{{ commits | length }}")]
+    #[case::index("{{ commits[0] }}")]
+    #[case::conditional("{% if commits %}nonempty{% endif %}")]
+    #[case::unreached("{% if false %}{{ commits }}{% endif %}")]
+    fn test_prompt_rejects_removed_commits(
+        #[case] template: &str,
+        #[values(false, true)] squash: bool,
+    ) {
+        let mut config = CommitGenerationConfig::default();
+        let template_type = if squash {
+            config.squash_template = Some(template.to_string());
+            TemplateType::Squash
+        } else {
+            config.template = Some(template.to_string());
+            TemplateType::Commit
+        };
+        let details = vec![CommitMessageDetail {
+            subject: "Subject".to_string(),
+            body: "Body".to_string(),
+        }];
+        let context = if squash {
+            squash_context("diff", "feature", None, "repo", &details, "main")
+        } else {
+            commit_context("diff", "feature", None, "repo")
+        };
+        let error = build_prompt(&config, template_type, &context).unwrap_err();
+        let message = error.to_string();
+        insta::allow_duplicates! {
+            if squash {
+                assert_snapshot!(message.ansi_strip(), @"Template commit.generation.squash-template uses removed variable commits; use commit_details (run wt config update)");
+            } else {
+                assert_snapshot!(message.ansi_strip(), @"Template commit.generation.template uses removed variable commits; use commit_details (run wt config update)");
+            }
+        }
+    }
+
+    #[rstest::rstest]
+    fn test_prompt_append_rejects_removed_commits(
+        #[values(false, true)] project: bool,
+        #[values(false, true)] squash: bool,
+    ) {
+        let mut config = CommitGenerationConfig::default();
+        let mut context = commit_context("diff", "feature", None, "repo");
+        if project {
+            context.project_append = Some("{{ commits | length }}");
+        } else {
+            config.template_append = Some("{{ commits | length }}".to_string());
+        }
+        let template_type = if squash {
+            TemplateType::Squash
+        } else {
+            TemplateType::Commit
+        };
+        let error = build_prompt(&config, template_type, &context).unwrap_err();
+        let message = error.to_string();
+        insta::allow_duplicates! {
+            if project {
+                assert_snapshot!(message.ansi_strip(), @"Template project commit.generation.template-append uses removed variable commits; use commit_details (run wt config update)");
+            } else {
+                assert_snapshot!(message.ansi_strip(), @"Template user commit.generation.template-append uses removed variable commits; use commit_details (run wt config update)");
+            }
+        }
+    }
+
+    #[rstest::rstest]
+    #[case::literal("commits: {{ 'commits' }}", "commits: commits")]
+    #[case::comment("{# {{ commits }} #}ok", "ok")]
+    #[case::local("{% set commits = 'local' %}{{ commits }}", "local")]
+    #[case::loop_binding("{% for commits in ['a', 'b'] %}{{ commits }}{% endfor %}", "ab")]
+    #[case::object_field("{% set data = {'commits': 'field'} %}{{ data.commits }}", "field")]
+    #[case::other_unknown("{{ other_commits }}", "")]
+    fn test_prompt_preserves_non_global_commits(#[case] template: &str, #[case] expected: &str) {
+        let config = CommitGenerationConfig {
+            squash_template: Some(template.to_string()),
+            ..Default::default()
+        };
+        let context = squash_context("diff", "feature", None, "repo", &[], "main");
+        assert_eq!(
+            build_prompt(&config, TemplateType::Squash, &context).unwrap(),
+            expected
+        );
+    }
+
     #[test]
     fn test_build_squash_prompt_with_custom_template() {
         let config = CommitGenerationConfig {
             command: None,
             template: None,
             squash_template: Some(
-                "Target: {{ target_branch }}\n{% for c in commits %}{{ c }}\n{% endfor %}"
+                "Target: {{ target_branch }}\n{% for c in commit_details %}{{ c }}\n{% endfor %}"
                     .to_string(),
             ),
             template_append: None,
@@ -1729,7 +1802,7 @@ mod tests {
             command: None,
             template: None,
             squash_template: Some(
-                "Repo: {{ repo }}\nBranch: {{ branch }}\nTarget: {{ target_branch }}\nDiff: {{ git_diff }}\n{% for c in commits %}{{ c }}\n{% endfor %}{% for r in recent_commits %}style: {{ r }}\n{% endfor %}"
+                "Repo: {{ repo }}\nBranch: {{ branch }}\nTarget: {{ target_branch }}\nDiff: {{ git_diff }}\n{% for c in commit_details %}{{ c }}\n{% endfor %}{% for r in recent_commits %}style: {{ r }}\n{% endfor %}"
                     .to_string(),
             ),
             template_append: None,
@@ -1827,14 +1900,14 @@ Diff follows:
             command: None,
             template: None,
             squash_template: Some(
-                r#"Squashing {{ commits | length }} commit(s) from {{ branch }} to {{ target_branch }}
-{% if commits | length > 1 -%}
+                r#"Squashing {{ commit_details | length }} commit(s) from {{ branch }} to {{ target_branch }}
+{% if commit_details | length > 1 -%}
 Multiple commits detected:
-{%- for c in commits %}
+{%- for c in commit_details %}
   {{ loop.index }}/{{ loop.length }}: {{ c }}
 {%- endfor %}
 {%- else -%}
-Single commit: {{ commits[0] }}
+Single commit: {{ commit_details[0] }}
 {%- endif %}"#
                     .to_string(),
             ),
@@ -1886,7 +1959,7 @@ Single commit: {{ commits[0] }}
         let config = CommitGenerationConfig {
             command: None,
             template: Some(
-                "Branch: {{ branch }}\nTarget: {{ target_branch }}\nCommit subjects: {{ commits | length }}\nCommit details: {{ commit_details | length }}"
+                "Branch: {{ branch }}\nTarget: {{ target_branch }}\nCommit details: {{ commit_details | length }}"
                     .to_string(),
             ),
             squash_template: None,
@@ -1897,10 +1970,7 @@ Single commit: {{ commits[0] }}
         assert!(result.is_ok());
         let prompt = result.unwrap();
         // Squash-specific variables are empty for regular commits
-        assert_eq!(
-            prompt,
-            "Branch: feature\nTarget: \nCommit subjects: 0\nCommit details: 0"
-        );
+        assert_eq!(prompt, "Branch: feature\nTarget: \nCommit details: 0");
     }
 
     // Tests for diff filtering

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -3950,7 +3950,10 @@ fn test_config_update_does_not_materialize_json_schema(repo: TestRepo) {
 /// element renders as its subject, so the migrated template renders identically
 /// to the original.
 #[rstest]
-fn test_config_update_migrates_commits_squash_var(repo: TestRepo) {
+fn test_config_update_migrates_commits_squash_var(mut repo: TestRepo) {
+    let feature_wt = repo.add_worktree("feature");
+    repo.commit_in_worktree(&feature_wt, "a.txt", "a\n", "Add a");
+    repo.commit_in_worktree(&feature_wt, "b.txt", "b\n", "Add b");
     let config_path = repo.test_config_path();
     fs::write(
         config_path,
@@ -3962,6 +3965,15 @@ Combine {{ commits | length }} commits:
 "#,
     )
     .unwrap();
+
+    let before = repo
+        .wt_command()
+        .args(["step", "squash", "main", "--show-prompt"])
+        .current_dir(&feature_wt)
+        .output()
+        .unwrap();
+    assert!(!before.status.success());
+    assert!(before.stdout.is_empty());
 
     let output = repo
         .wt_command()
@@ -3989,6 +4001,29 @@ Combine {{ commits | length }} commits:
         !updated.contains("{{ commits"),
         "no deprecated commits reference should remain: {updated}"
     );
+    let rendered = repo
+        .wt_command()
+        .args(["step", "squash", "main", "--show-prompt"])
+        .current_dir(&feature_wt)
+        .output()
+        .unwrap();
+    assert!(
+        rendered.status.success(),
+        "{}",
+        String::from_utf8_lossy(&rendered.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(rendered.stdout).unwrap(),
+        "Combine 2 commits:\n- Add a\n- Add b\n\n"
+    );
+    assert!(rendered.stderr.is_empty());
+    let again = repo
+        .wt_command()
+        .args(["config", "update", "--yes"])
+        .output()
+        .unwrap();
+    assert!(again.status.success());
+    assert_eq!(fs::read_to_string(config_path).unwrap(), updated);
 }
 
 /// A relative `--config` resolves against `-C`, the way git resolves the path

--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -1,10 +1,11 @@
 use crate::common::{
     SLEEP_FOR_ABSENCE_CHECK, TestRepo, make_snapshot_cmd, merge_scenario,
-    mock_commands::{create_mock_cargo, create_mock_llm_auth},
+    mock_commands::{create_mock_cargo, create_mock_llm_auth, mock_calls},
     repo, repo_with_alternate_primary, repo_with_main_worktree, repo_with_multi_commit_feature,
-    repo_with_remote, setup_snapshot_settings, wait_for_file, wait_for_file_content,
+    repo_with_remote, setup_snapshot_settings, test_tempdir, wait_for_file, wait_for_file_content,
     wait_for_worktree_removed,
 };
+use ansi_str::AnsiStr;
 use insta::assert_snapshot;
 use insta_cmd::assert_cmd_snapshot;
 use path_slash::PathExt as _;
@@ -2782,13 +2783,10 @@ squash-template = """
     ));
 }
 
-/// A custom squash template that references the deprecated `commits` variable
-/// still renders, and the standard config-deprecation framework warns that it
-/// is replaced by `commit_details` and points at `wt config update` to apply
-/// the rewrite (see #2984). The rename is mechanical because each
-/// `commit_details` element renders as its subject when printed bare.
+/// Removed prompt variables fail even in the read-only preview. The existing
+/// config warning and the rendering error both retain the migration route.
 #[rstest]
-fn test_step_squash_show_prompt_deprecated_commits_warns(mut repo: TestRepo) {
+fn test_step_squash_show_prompt_removed_commits_errors(mut repo: TestRepo) {
     let feature_wt = repo.add_worktree("feature");
 
     repo.commit_in_worktree(&feature_wt, "a.txt", "a\n", "Add a");
@@ -2806,6 +2804,71 @@ squash-template = "Squashing {{ commits | length }} commits from {{ branch }}"
         &["squash", "--show-prompt"],
         Some(&feature_wt),
     ));
+}
+
+/// A bad prompt must not invoke the configured generator or replace either
+/// branch, whether squash is invoked directly or through merge.
+#[rstest]
+#[case::squash(&["step", "squash", "main"])]
+#[case::merge(&["merge", "main"])]
+fn test_removed_commits_stops_generation(#[case] args: &[&str], mut repo: TestRepo) {
+    let feature_wt = repo.add_worktree("feature");
+    repo.commit_in_worktree(&feature_wt, "a.txt", "a\n", "Add a");
+    repo.commit_in_worktree(&feature_wt, "b.txt", "b\n", "Add b");
+    let before = repo
+        .git_command()
+        .args(["rev-parse", "main", "feature"])
+        .run()
+        .unwrap()
+        .stdout;
+    assert!(
+        repo.git_command()
+            .args(["status", "--porcelain"])
+            .run()
+            .unwrap()
+            .stdout
+            .is_empty()
+    );
+
+    let external = test_tempdir();
+    let bin_dir = external.path().join("bin");
+    fs::create_dir(&bin_dir).unwrap();
+    create_mock_llm_auth(&bin_dir);
+    fs::write(
+        repo.test_config_path(),
+        r#"
+[commit.generation]
+command = "llm"
+squash-template = "{{ commits | length }}"
+"#,
+    )
+    .unwrap();
+    let (path_var, path_with_bin) = make_path_with_mock_bin(&bin_dir);
+    let output = repo
+        .wt_command()
+        .args(args)
+        .current_dir(&feature_wt)
+        .env(path_var, path_with_bin)
+        .env("WORKTRUNK_TEST_MOCK_CONFIG_DIR", &bin_dir)
+        .env("WORKTRUNK_TEST_MOCK_CALL_LOG_DIR", external.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .ansi_strip()
+            .contains("uses removed variable commits")
+    );
+    assert!(mock_calls(external.path(), "llm").is_empty());
+    assert_eq!(
+        repo.git_command()
+            .args(["rev-parse", "main", "feature"])
+            .run()
+            .unwrap()
+            .stdout,
+        before
+    );
+    assert!(feature_wt.exists());
 }
 
 // =============================================================================

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -435,6 +435,9 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# - `{{ commit_details }}` — list of commits being squashed; each renders as its subject and exposes `.subject` / `.body`[0m
 [107m [0m [2m# - `{{ target_branch }}` — merge target branch[0m
 [107m [0m [2m#[0m
+[107m [0m [2m# The old `commits` variable has been removed. Run `wt config update` to migrate existing prompt templates to `commit_details`.[0m
+[107m [0m [2m# Each detail still renders as its subject when printed directly; `.body` remains available separately.[0m
+[107m [0m [2m#[0m
 [107m [0m [2m# Default template:[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# <!-- DEFAULT_SQUASH_TEMPLATE_START -->[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -481,6 +481,9 @@ Available variables (in addition to commit template variables):
 - [2m{{ commit_details }}[0m — list of commits being squashed; each renders as its subject and exposes [2m.subject[0m / [2m.body[0m
 - [2m{{ target_branch }}[0m — merge target branch
 
+The old [2mcommits[0m variable has been removed. Run [2mwt config update[0m to migrate existing prompt templates to [2mcommit_details[0m.
+Each detail still renders as its subject when printed directly; [2m.body[0m remains available separately.
+
 Default template:
 
 [107m [0m [2m[36m[commit.generation][0m

--- a/tests/snapshots/integration__integration_tests__merge__step_squash_show_prompt_removed_commits_errors.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_squash_show_prompt_removed_commits_errors.snap
@@ -55,11 +55,11 @@ info:
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
-success: true
-exit_code: 0
+success: false
+exit_code: 1
 ----- stdout -----
-Squashing 2 commits from feature
 
 ----- stderr -----
 [33m▲[39m [33mUser config: template variable [1mcommits[22m is deprecated in favor of [1mcommit_details[22m[39m
 [2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
+[31m✗[39m [31mTemplate [1mcommit.generation.squash-template[22m uses removed variable [1mcommits[22m; use [1mcommit_details[22m (run [1mwt config update[22m)[39m


### PR DESCRIPTION
Fixes #2984.

## Changes

- Stop supplying the removed `commits` variable to commit/squash prompts and user/project append fragments. Parsed-template validation reports the affected setting, `commit_details`, and `wt config update`; literals, comments, local bindings, and unrelated variables remain unaffected.
- Keep the retirement check and replacement mapping in the config-deprecation layer. Validation runs when building a prompt, not while loading config, so `config show`, `config update`, and unrelated commands can still work with an old config. The existing warning/update invariant and migration rule remain intact.
- Preserve subject-only loops during migration through the existing `CommitDetailValue` rendering. Update the removal/recovery notes and generated help/config documentation. This implements the requested removal step, with no wall-clock check or reintroduction of the old name as an object alias.

## Validation

- `cargo run -- hook pre-merge --yes`: 4,868 tests passed with all features; the existing nightly-only crate-archive build test remains ignored. Pre-commit/clippy, Rust documentation, and doctests passed.
- Regression coverage includes 22 primary/append-template cases, preview failure, real `step squash` and `merge` calls that neither invoke the configured generator nor change branch refs, and a config-update/render/idempotence test.
- An independent old/new binary check confirms that migration preserves the prompt byte-for-byte. Rejected operations leave both refs and the generator call count unchanged; after migration, a real squash invokes that same recorder exactly once and retains the target branch.
- Three targeted omission checks detect removal of either rendering guard or the migration entry; the restored source passes again.
- Generated docs/help synchronization, Astro checks, 15 documentation-renderer tests, and the production docs build passed.

Linux validation used the pinned Rust 1.97 toolchain and Git 2.54.0, plus real bash/zsh/fish/Nushell/PowerShell test shells. The test process used the standard umask and dropped root's file-permission-bypass capabilities so the existing permission assertions were meaningful. The suite's explicit UID-based skips still apply. Native cross-platform CI is still separate from these local results.
